### PR TITLE
Fix PlatformIO compile errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ a.out
 test
 cmake-build-*
 ClusterDuck-Protokoll.code-workspace
+CDP-All.code-workspace

--- a/examples/1.Ducks/DetectorDuck/.gitignore
+++ b/examples/1.Ducks/DetectorDuck/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/1.Ducks/DetectorDuck/platformio.ini
+++ b/examples/1.Ducks/DetectorDuck/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/1.Ducks/DetectorDuck/platformio.ini
+++ b/examples/1.Ducks/DetectorDuck/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/1.Ducks/DetectorDuck/platformio.ini
+++ b/examples/1.Ducks/DetectorDuck/platformio.ini
@@ -11,15 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/1.Ducks/DuckLink/.gitignore
+++ b/examples/1.Ducks/DuckLink/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/1.Ducks/DuckLink/platformio.ini
+++ b/examples/1.Ducks/DuckLink/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/1.Ducks/DuckLink/platformio.ini
+++ b/examples/1.Ducks/DuckLink/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/1.Ducks/DuckLink/platformio.ini
+++ b/examples/1.Ducks/DuckLink/platformio.ini
@@ -11,15 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/1.Ducks/MamaDuck/platformio.ini
+++ b/examples/1.Ducks/MamaDuck/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/1.Ducks/MamaDuck/platformio.ini
+++ b/examples/1.Ducks/MamaDuck/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/1.Ducks/MamaDuck/platformio.ini
+++ b/examples/1.Ducks/MamaDuck/platformio.ini
@@ -11,15 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/1.Ducks/PapaDuck/platformio.ini
+++ b/examples/1.Ducks/PapaDuck/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/1.Ducks/PapaDuck/platformio.ini
+++ b/examples/1.Ducks/PapaDuck/platformio.ini
@@ -11,17 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    knolleary/PubSubClient
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
 
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/1.Ducks/PapaDuck/platformio.ini
+++ b/examples/1.Ducks/PapaDuck/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/.gitignore
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -11,15 +11,76 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -11,76 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Example/.gitignore
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/2.Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -11,15 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/2.Custom-Mama-Examples/Custom-Portal-Example/.gitignore
+++ b/examples/2.Custom-Mama-Examples/Custom-Portal-Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/2.Custom-Mama-Examples/Custom-Portal-Example/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Portal-Example/platformio.ini
@@ -11,16 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    ClusterDuck Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
 
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/2.Custom-Mama-Examples/Custom-Portal-Example/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Portal-Example/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/2.Custom-Mama-Examples/Custom-Portal-Example/platformio.ini
+++ b/examples/2.Custom-Mama-Examples/Custom-Portal-Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/3.Sensor-Examples/BMP180Example/.gitignore
+++ b/examples/3.Sensor-Examples/BMP180Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/3.Sensor-Examples/BMP180Example/platformio.ini
+++ b/examples/3.Sensor-Examples/BMP180Example/platformio.ini
@@ -11,16 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    adafruit/Adafruit BMP085 Library
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/BMP180Example/platformio.ini
+++ b/examples/3.Sensor-Examples/BMP180Example/platformio.ini
@@ -11,79 +11,34 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	adafruit/Adafruit BMP085 Unified @ ^1.1.3
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/BMP180Example/platformio.ini
+++ b/examples/3.Sensor-Examples/BMP180Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	adafruit/Adafruit BMP085 Unified @ ^1.1.3
 	SPI
     ArduinoOTA

--- a/examples/3.Sensor-Examples/BMP280Example/.gitignore
+++ b/examples/3.Sensor-Examples/BMP280Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/3.Sensor-Examples/BMP280Example/platformio.ini
+++ b/examples/3.Sensor-Examples/BMP280Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	adafruit/Adafruit BMP280 Library @ ^2.6.8
 	SPI
     ArduinoOTA

--- a/examples/3.Sensor-Examples/BMP280Example/platformio.ini
+++ b/examples/3.Sensor-Examples/BMP280Example/platformio.ini
@@ -11,79 +11,34 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	adafruit/Adafruit BMP280 Library @ ^2.6.8
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/BMP280Example/platformio.ini
+++ b/examples/3.Sensor-Examples/BMP280Example/platformio.ini
@@ -11,16 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    adafruit/Adafruit BMP280 Library
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/DHT11Example/.gitignore
+++ b/examples/3.Sensor-Examples/DHT11Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/3.Sensor-Examples/DHT11Example/platformio.ini
+++ b/examples/3.Sensor-Examples/DHT11Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
  	adafruit/DHT sensor library @ ^1.4.6
 	adafruit/Adafruit Unified Sensor @ ^1.1.14
 	SPI

--- a/examples/3.Sensor-Examples/DHT11Example/platformio.ini
+++ b/examples/3.Sensor-Examples/DHT11Example/platformio.ini
@@ -11,16 +11,80 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+    adafruit/DHT sensor library
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    adafruit/DHT sensor library
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/DHT11Example/platformio.ini
+++ b/examples/3.Sensor-Examples/DHT11Example/platformio.ini
@@ -11,80 +11,36 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+ 	adafruit/DHT sensor library @ ^1.4.6
+	adafruit/Adafruit Unified Sensor @ ^1.1.14
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
-    adafruit/DHT sensor library
+	UPDATE
+   
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/DustSensorExample/.gitignore
+++ b/examples/3.Sensor-Examples/DustSensorExample/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/3.Sensor-Examples/DustSensorExample/platformio.ini
+++ b/examples/3.Sensor-Examples/DustSensorExample/platformio.ini
@@ -11,16 +11,80 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+    luciansabo/Sharp GP2Y Dust Sensor
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    luciansabo/Sharp GP2Y Dust Sensor
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/DustSensorExample/platformio.ini
+++ b/examples/3.Sensor-Examples/DustSensorExample/platformio.ini
@@ -11,80 +11,34 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
     luciansabo/Sharp GP2Y Dust Sensor
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/DustSensorExample/platformio.ini
+++ b/examples/3.Sensor-Examples/DustSensorExample/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/3.Sensor-Examples/MQ7Example/.gitignore
+++ b/examples/3.Sensor-Examples/MQ7Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/3.Sensor-Examples/MQ7Example/platformio.ini
+++ b/examples/3.Sensor-Examples/MQ7Example/platformio.ini
@@ -11,80 +11,34 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
     miguel5612/MQUnifiedsensor
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/MQ7Example/platformio.ini
+++ b/examples/3.Sensor-Examples/MQ7Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/3.Sensor-Examples/MQ7Example/platformio.ini
+++ b/examples/3.Sensor-Examples/MQ7Example/platformio.ini
@@ -11,16 +11,80 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+    miguel5612/MQUnifiedsensor
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    miguel5612/MQUnifiedsensor
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/WS2812Example/.gitignore
+++ b/examples/3.Sensor-Examples/WS2812Example/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/3.Sensor-Examples/WS2812Example/platformio.ini
+++ b/examples/3.Sensor-Examples/WS2812Example/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/3.Sensor-Examples/WS2812Example/platformio.ini
+++ b/examples/3.Sensor-Examples/WS2812Example/platformio.ini
@@ -11,16 +11,80 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+    fastled/FastLED
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    fastled/FastLED
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/3.Sensor-Examples/WS2812Example/platformio.ini
+++ b/examples/3.Sensor-Examples/WS2812Example/platformio.ini
@@ -11,80 +11,34 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
     fastled/FastLED
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/4.Ble-Duck-App/Ble-Duck-App/.gitignore
+++ b/examples/4.Ble-Duck-App/Ble-Duck-App/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/4.Ble-Duck-App/Ble-Duck-App/platformio.ini
+++ b/examples/4.Ble-Duck-App/Ble-Duck-App/platformio.ini
@@ -11,79 +11,33 @@
 [platformio]
 src_dir = .
 
-[common]
+[env]
 build_flags =
-    -I include
-
-lib_deps_builtin =
-    SPI
+	-I include
+lib_deps =
+	../../../
+	SPI
     ArduinoOTA
     WIRE
-
-lib_deps_external =
-    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
-    bblanchon/ArduinoJson@^6.21.0
-    contrem/arduino-timer@^3.0.0
-    bakercp/CRC32@^2.0.0
-    jgromes/RadioLib@^5.6.0
-    OperatorFoundation/Crypto@^0.4.0
-    esphome/ESPAsyncWebServer-esphome@^3.1.0
-    me-no-dev/AsyncTCP@^1.1.1
-    knolleary/PubSubClient@^2.8
-    olikraus/U8g2@^2.35.8
+	UPDATE
 
 [env:heltec_wifi_lora_32_V2]
 framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-
-; Build flags
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-lora32-v21]
-platform =  espressif32
+platform = espressif32
 board = ttgo-lora32-v21
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_ldf_mode = deep+
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-
 
 [env:ttgo-t-beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
-
-; Build options
-build_flags = ${common.build_flags}
-
-; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
-
-; Library options
-lib_deps =
-    ${common.lib_deps_builtin}
-    ${common.lib_deps_external}
-lib_ldf_mode = deep+

--- a/examples/4.Ble-Duck-App/Ble-Duck-App/platformio.ini
+++ b/examples/4.Ble-Duck-App/Ble-Duck-App/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/4.Ble-Duck-App/Ble-Duck-App/platformio.ini
+++ b/examples/4.Ble-Duck-App/Ble-Duck-App/platformio.ini
@@ -11,15 +11,79 @@
 [platformio]
 src_dir = .
 
+[common]
+build_flags =
+    -I include
+
+lib_deps_builtin =
+    SPI
+    ArduinoOTA
+    WIRE
+
+lib_deps_external =
+    https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git
+    bblanchon/ArduinoJson@^6.21.0
+    contrem/arduino-timer@^3.0.0
+    bakercp/CRC32@^2.0.0
+    jgromes/RadioLib@^5.6.0
+    OperatorFoundation/Crypto@^0.4.0
+    esphome/ESPAsyncWebServer-esphome@^3.1.0
+    me-no-dev/AsyncTCP@^1.1.1
+    knolleary/PubSubClient@^2.8
+    olikraus/U8g2@^2.35.8
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
-framework = arduino
+
+; Build flags
+build_flags = ${common.build_flags}
+
+; Serial monitor options
 monitor_speed = 115200
 monitor_filters = time
 
+; Library options
+lib_ldf_mode = deep+
 lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
 
-; uncomment for OTA update
-; upload_port = duck.local
+
+[env:ttgo-lora32-v21]
+platform =  espressif32
+board = ttgo-lora32-v21
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_ldf_mode = deep+
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+
+
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+
+; Build options
+build_flags = ${common.build_flags}
+
+; Serial monitor options
+monitor_speed = 115200
+monitor_filters = time
+
+; Library options
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps_external}
+lib_ldf_mode = deep+

--- a/examples/5.Custom-Papa-Examples/Papa-DishDuck-WiFi/platformio.ini
+++ b/examples/5.Custom-Papa-Examples/Papa-DishDuck-WiFi/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../../ClusterDuck-Protocol
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git../ClusterDuck-Protocol
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/5.Custom-Papa-Examples/Papa-DishDuck-WiFi/platformio.ini
+++ b/examples/5.Custom-Papa-Examples/Papa-DishDuck-WiFi/platformio.ini
@@ -11,17 +11,34 @@
 [platformio]
 src_dir = .
 
+[env]
+build_flags =
+	-I include
+lib_deps =
+	../../../../ClusterDuck-Protocol
+	SPI
+    ArduinoOTA
+    WIRE
+	UPDATE
+    mikalhart/IridiumSBD
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
+monitor_speed = 115200
+monitor_filters = time
+
+[env:ttgo-lora32-v21]
+platform = espressif32
+board = ttgo-lora32-v21
 framework = arduino
 monitor_speed = 115200
 monitor_filters = time
 
-lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    mikalhart/IridiumSBD
-    knolleary/PubSubClient
-
-; uncomment for OTA update
-; upload_port = duck.local
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+monitor_speed = 115200
+monitor_filters = time

--- a/examples/5.Custom-Papa-Examples/Papa-DishDuck/platformio.ini
+++ b/examples/5.Custom-Papa-Examples/Papa-DishDuck/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 build_flags =
 	-I include
 lib_deps =
-	../../../../ClusterDuck-Protocol
+	https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git../ClusterDuck-Protocol
 	SPI
     ArduinoOTA
     WIRE

--- a/examples/5.Custom-Papa-Examples/Papa-DishDuck/platformio.ini
+++ b/examples/5.Custom-Papa-Examples/Papa-DishDuck/platformio.ini
@@ -11,17 +11,34 @@
 [platformio]
 src_dir = .
 
+[env]
+build_flags =
+	-I include
+lib_deps =
+	../../../../ClusterDuck-Protocol
+	SPI
+    ArduinoOTA
+    WIRE
+	UPDATE
+    mikalhart/IridiumSBD
+
 [env:heltec_wifi_lora_32_V2]
+framework = arduino
 platform = espressif32
 board = heltec_wifi_lora_32_V2
+monitor_speed = 115200
+monitor_filters = time
+
+[env:ttgo-lora32-v21]
+platform = espressif32
+board = ttgo-lora32-v21
 framework = arduino
 monitor_speed = 115200
 monitor_filters = time
 
-lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
-    mikalhart/IridiumSBD
-    knolleary/PubSubClient
-
-; uncomment for OTA update
-; upload_port = duck.local
+[env:ttgo-t-beam]
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+monitor_speed = 115200
+monitor_filters = time

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/Call-for-Code/ClusterDuck-Protocol.git"
+        "url": "https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol.git"
     },
     "export":
     {
@@ -35,7 +35,7 @@
         "bakercp/CRC32": "2.0.0",
         "jgromes/RadioLib": "^5.1.2",
         "operatorfoundation/Crypto": "^0.4.0",
-        "me-no-dev/ESP Async WebServer": "^1.2.3",
+        "esphome/ESPAsyncWebServer-esphome": "^3.1.0",
         "knolleary/pubsubclient":"^2.8.0"
     }
 }


### PR DESCRIPTION
Changes to platformio.ini files for some example programs. Now working with correct lib_deps and updated PlatformIO espressif32 lib (prev version didn't support ttgo-lora32-v21). 

Tested building for these boards:
- heltec_wifi_lora_32_V2
- ttgo-lora32-v21
- ttgo-t-beam


