### PR TITLE
Fixed issues in platformio for cubecell v2. Switch compiler to gnu++11

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -70,10 +70,11 @@
       -DCubeCell_GPS
 
 [env:cubecell_board_v2]
-  extends = env:cubecell_base
+  extends = cubecell_base
   board = cubecell_board_v2
   build_flags =
       ${cubecell_base.build_flags}
+      -std=gnu++11
       -DCubeCell_Board
 
 ;;--------------------------------------------------------------------------------


### PR DESCRIPTION
**What is is PR for?**

- [ ] Code update
- [ ] Documentation update
- [x] Infrastructure update

**What does this PR do?**  
Fixes broken build issue issue with CubeCell Board v2

**Is this related to an open issue?**  
#412

**Testing methodology**  
Run the build command `platformio run -e cubecell_board_v2 `

**Additional context**  
The build failure was caused by and incorrect `extends` statement
```
[env:cubecell_board_v2]
  extends = ${env.cubecell_base}
```

The correct statement is `extends = cubecell_base`

**Checklist**
Before you submit this pull request, please make sure you have done the following:

_General_  

- [x] Contribution Guidelines: Have you read the contribution guidelines?
- [x] Code of Conduct: Have you read the code of conduct?
- [x] Documentation: If applicable, have you added or updated all relevant documentation?

_For Code Updates_  

- [x] Hardware Validation: If relevant, have you validated your changes on actual supported Duck hardware?
- [x] Unit Tests: Have you run the unit tests on the device?
- [ ] Network Testing: If applicable, have you tested your changes on a Duck network?
- [ ] Licensing: Have you added a copyright and license header to each new file?

_Tested Targets (Please check all that apply)_

- [ ] All
- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [x] Heltec CubeCell Series
- [ ] TTGO T-Beam (SX1262)
- [ ] Others
