### PR TITLE
Use Latest Release Tag for PIO CDP Install

### DIFF
--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -48,7 +48,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/releases/tag/4.2.0  ; CDP from master branch
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -31,7 +31,7 @@
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_t_beam
 
-description = DuckLink CDP examples
+description = DetectorDuck CDP examples
 
 [env]
    lib_deps = 

--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -48,7 +48,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/releases/tag/4.2.0  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip  ; CDP from master branch
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Basic-Ducks/DuckLink/platformio.ini
+++ b/examples/Basic-Ducks/DuckLink/platformio.ini
@@ -48,7 +48,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Basic-Ducks/MamaDuck/platformio.ini
+++ b/examples/Basic-Ducks/MamaDuck/platformio.ini
@@ -48,7 +48,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Basic-Ducks/MamaDuck/platformio.ini
+++ b/examples/Basic-Ducks/MamaDuck/platformio.ini
@@ -31,7 +31,7 @@
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_t_beam
 
-description = DuckLink CDP examples
+description = MamaDuck CDP examples
 
 [env]
    lib_deps = 

--- a/examples/Basic-Ducks/PapaDuck/platformio.ini
+++ b/examples/Basic-Ducks/PapaDuck/platformio.ini
@@ -31,7 +31,7 @@
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_t_beam
 
-description = DuckLink CDP examples
+description = PapaDuck CDP examples
 
 [env]
    lib_deps = 

--- a/examples/Basic-Ducks/PapaDuck/platformio.ini
+++ b/examples/Basic-Ducks/PapaDuck/platformio.ini
@@ -48,7 +48,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -1,25 +1,157 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [platformio]
-src_dir = .
+   src_dir = .
+;; uncomment the line below to build for your board
 
-[env:heltec_wifi_lora_32_V2]
-platform = espressif32
-board = heltec_wifi_lora_32_V2
-framework = arduino
-monitor_speed = 115200
-monitor_filters = time
+   default_envs = local_heltec_wifi_lora_32_V3
+;   default_envs = local_heltec_wifi_lora_32_V3
+;   default_envs = local_heltec_wifi_lora_32_V2
+;   default_envs = local_ttgo_t_beam
 
-lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+;   default_envs = prod_heltec_wifi_lora_32_V3
+;   default_envs = prod_heltec_wifi_lora_32_V2
+;   default_envs = prod_ttgo_t_beam
 
-; uncomment for OTA update
-; upload_port = duck.local
+description = Custom Mama Detect examples
+
+[env]
+   lib_deps = 
+      WIRE
+      SPI
+      contrem/arduino-timer@^3.0.1
+      bblanchon/ArduinoJson@7.0.3
+      olikraus/U8g2@^2.35.9
+
+[env:esp32]
+   lib_deps = knolleary/pubsubclient@^2.8.0
+
+[env:local_cdp]
+   lib_deps = symlink://../../../ ; local CDP library      
+
+[env:release_cdp]
+   lib_deps = 
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+
+; -------------------------------------------------------------------------------------------------------      
+; ---- PRODUCTION ENVIRONMENTS
+; -------------------------------------------------------------------------------------------------------
+
+
+; PRODUCTION HELTEC_WIFI_LORA_32_V2
+[env:prod_heltec_wifi_lora_32_V2]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+      
+; PRODUCTION HELTEC_WIFI_LORA_32_V3
+[env:prod_heltec_wifi_lora_32_V3]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V3
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+      
+; PRODUCTION LILYGO_T_BEAM_SX1262   
+[env:prod_lilygo_t_beam_sx1262]
+   platform = espressif32
+   board = ttgo-t-beam
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+
+; PRODUCTION TTGO_LORA32_V1
+[env:prod_ttgo_lora32_v1]
+   platform = espressif32
+   board = ttgo-lora32-v1
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+
+; PRODUCTION CUBECELL_BOARD_V2
+[env:prod_cubecell_board_v2]
+   platform = https://github.com/HelTecAutomation/heltec-cubecell.git
+   board = cubecell_board_v2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   build_flags =
+      -DCubeCell_Board
+   lib_ignore = 
+      ESP Async WebServer
+   lib_deps = 
+      ${env:release_cdp.lib_deps}
+
+; -------------------------------------------------------------------------------------------------------      
+; ---- LOCAL ENVIRONMENTS
+; -------------------------------------------------------------------------------------------------------
+
+; LOCAL HELTEC_WIFI_LORA_32_V2
+[env:local_heltec_wifi_lora_32_V2]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+      
+; LOCAL HELTEC_WIFI_LORA_32_V3
+[env:local_heltec_wifi_lora_32_V3]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V3
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+
+; LOCAL LILYGO_T_BEAM_SX1262      
+[env:local_lilygo_t_beam_sx1262]
+   platform = espressif32
+   board = ttgo-t-beam
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+
+; LOCAL TTGO_LORA32_V1
+[env:local_ttgo_lora32_v1]
+   platform = espressif32
+   board = ttgo-lora32-v1
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+      
+; LOCAL CUBECELL_BOARD_V2
+[env:local_cubecell_board_v2]
+   platform = https://github.com/HelTecAutomation/heltec-cubecell.git
+   board = cubecell_board_v2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   build_flags =
+      -DCubeCell_Board
+   lib_ignore =
+      ESP Async WebServer
+   lib_deps = 
+      ${env:local_cdp.lib_deps}

--- a/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -1,25 +1,157 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [platformio]
-src_dir = .
+   src_dir = .
+;; uncomment the line below to build for your board
 
-[env:heltec_wifi_lora_32_V2]
-platform = espressif32
-board = heltec_wifi_lora_32_V2
-framework = arduino
-monitor_speed = 115200
-monitor_filters = time
+   default_envs = local_heltec_wifi_lora_32_V3
+;   default_envs = local_heltec_wifi_lora_32_V3
+;   default_envs = local_heltec_wifi_lora_32_V2
+;   default_envs = local_ttgo_t_beam
 
-lib_deps =
-    https://github.com/Call-for-Code/ClusterDuck-Protocol
+;   default_envs = prod_heltec_wifi_lora_32_V3
+;   default_envs = prod_heltec_wifi_lora_32_V2
+;   default_envs = prod_ttgo_t_beam
 
-; uncomment for OTA update
-; upload_port = duck.local
+description = Custom Mama examples
+
+[env]
+   lib_deps = 
+      WIRE
+      SPI
+      contrem/arduino-timer@^3.0.1
+      bblanchon/ArduinoJson@7.0.3
+      olikraus/U8g2@^2.35.9
+
+[env:esp32]
+   lib_deps = knolleary/pubsubclient@^2.8.0
+
+[env:local_cdp]
+   lib_deps = symlink://../../../ ; local CDP library      
+
+[env:release_cdp]
+   lib_deps = 
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+
+; -------------------------------------------------------------------------------------------------------      
+; ---- PRODUCTION ENVIRONMENTS
+; -------------------------------------------------------------------------------------------------------
+
+
+; PRODUCTION HELTEC_WIFI_LORA_32_V2
+[env:prod_heltec_wifi_lora_32_V2]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+      
+; PRODUCTION HELTEC_WIFI_LORA_32_V3
+[env:prod_heltec_wifi_lora_32_V3]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V3
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+      
+; PRODUCTION LILYGO_T_BEAM_SX1262   
+[env:prod_lilygo_t_beam_sx1262]
+   platform = espressif32
+   board = ttgo-t-beam
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+
+; PRODUCTION TTGO_LORA32_V1
+[env:prod_ttgo_lora32_v1]
+   platform = espressif32
+   board = ttgo-lora32-v1
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:release_cdp.lib_deps}
+
+; PRODUCTION CUBECELL_BOARD_V2
+[env:prod_cubecell_board_v2]
+   platform = https://github.com/HelTecAutomation/heltec-cubecell.git
+   board = cubecell_board_v2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   build_flags =
+      -DCubeCell_Board
+   lib_ignore = 
+      ESP Async WebServer
+   lib_deps = 
+      ${env:release_cdp.lib_deps}
+
+; -------------------------------------------------------------------------------------------------------      
+; ---- LOCAL ENVIRONMENTS
+; -------------------------------------------------------------------------------------------------------
+
+; LOCAL HELTEC_WIFI_LORA_32_V2
+[env:local_heltec_wifi_lora_32_V2]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+      
+; LOCAL HELTEC_WIFI_LORA_32_V3
+[env:local_heltec_wifi_lora_32_V3]
+   platform = espressif32
+   board = heltec_wifi_lora_32_V3
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+
+; LOCAL LILYGO_T_BEAM_SX1262      
+[env:local_lilygo_t_beam_sx1262]
+   platform = espressif32
+   board = ttgo-t-beam
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+
+; LOCAL TTGO_LORA32_V1
+[env:local_ttgo_lora32_v1]
+   platform = espressif32
+   board = ttgo-lora32-v1
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   lib_deps = 
+      ${env:esp32.lib_deps} 
+      ${env:local_cdp.lib_deps}
+      
+; LOCAL CUBECELL_BOARD_V2
+[env:local_cubecell_board_v2]
+   platform = https://github.com/HelTecAutomation/heltec-cubecell.git
+   board = cubecell_board_v2
+   framework = arduino
+   monitor_speed = 115200
+   monitor_filters = time
+   build_flags =
+      -DCubeCell_Board
+   lib_ignore =
+      ESP Async WebServer
+   lib_deps = 
+      ${env:local_cdp.lib_deps}

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
@@ -31,7 +31,7 @@
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_t_beam
 
-description = DuckLink CDP examples
+description = AWS PapaDuck CDP examples
 
 [env]
    lib_deps = 

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
@@ -48,7 +48,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
@@ -29,8 +29,7 @@ description = Papa MQTT CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol  ; CDP from master branch
-
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
 
 ; -------------------------------------------------------------------------------------------------------      
 ; ---- PRODUCTION ENVIRONMENTS

--- a/examples/External-Boards-Example/DuckLink/my-boards/heltec-cubecell-gps/pio_cubecell_gps.ini
+++ b/examples/External-Boards-Example/DuckLink/my-boards/heltec-cubecell-gps/pio_cubecell_gps.ini
@@ -9,7 +9,7 @@
   lib_deps = 
       WIRE
       SPI
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol 
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
       contrem/arduino-timer@^3.0.1
       bblanchon/ArduinoJson@^7.0.3  
 

--- a/examples/External-Boards-Example/DuckLink/my-boards/heltec-wireless-paper/pio_wireless_paper.ini
+++ b/examples/External-Boards-Example/DuckLink/my-boards/heltec-wireless-paper/pio_wireless_paper.ini
@@ -5,7 +5,7 @@
    monitor_speed = 115200
    monitor_filters = time
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol 
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
       WIRE
       SPI
       ARDUINOOTA


### PR DESCRIPTION
Switch to using the release tags instead of master for CDP's pio dependency
