### PR TITLE
Issue-454: Updated outdated example default_envs vars

### DIFF
--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -23,13 +23,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = DetectorDuck CDP examples
 

--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -25,11 +25,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = DetectorDuck CDP examples
 

--- a/examples/Basic-Ducks/DuckLink/platformio.ini
+++ b/examples/Basic-Ducks/DuckLink/platformio.ini
@@ -25,11 +25,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = DuckLink CDP examples
 

--- a/examples/Basic-Ducks/DuckLink/platformio.ini
+++ b/examples/Basic-Ducks/DuckLink/platformio.ini
@@ -23,13 +23,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = DuckLink CDP examples
 

--- a/examples/Basic-Ducks/MamaDuck/platformio.ini
+++ b/examples/Basic-Ducks/MamaDuck/platformio.ini
@@ -23,13 +23,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = MamaDuck CDP examples
 

--- a/examples/Basic-Ducks/MamaDuck/platformio.ini
+++ b/examples/Basic-Ducks/MamaDuck/platformio.ini
@@ -25,11 +25,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = MamaDuck CDP examples
 

--- a/examples/Basic-Ducks/PapaDuck/platformio.ini
+++ b/examples/Basic-Ducks/PapaDuck/platformio.ini
@@ -25,11 +25,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = PapaDuck CDP examples
 

--- a/examples/Basic-Ducks/PapaDuck/platformio.ini
+++ b/examples/Basic-Ducks/PapaDuck/platformio.ini
@@ -23,13 +23,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = PapaDuck CDP examples
 

--- a/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -5,11 +5,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = Custom Mama Detect examples
 

--- a/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -3,13 +3,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = Custom Mama Detect examples
 

--- a/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -3,13 +3,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = Custom Mama examples
 

--- a/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -5,11 +5,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = Custom Mama examples
 

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
@@ -25,11 +25,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = AWS PapaDuck CDP examples
 

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
@@ -23,13 +23,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = AWS PapaDuck CDP examples
 

--- a/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
@@ -5,11 +5,11 @@
    default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
-;   default_envs = local_ttgo_t_beam
+;   default_envs = local_ttgo_lora32_v1
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
-;   default_envs = prod_ttgo_t_beam
+;   default_envs = prod_ttgo_lora32_v1
 
 description = Papa MQTT CDP examples
 

--- a/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
@@ -3,13 +3,14 @@
 ;; uncomment the line below to build for your board
 
    default_envs = local_heltec_wifi_lora_32_V3
-;   default_envs = local_heltec_wifi_lora_32_V3
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_ttgo_lora32_v1
+;   default_envs = local_lilygo_t_beam_sx1262
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_ttgo_lora32_v1
+;   default_envs = prod_lilygo_t_beam_sx1262
 
 description = Papa MQTT CDP examples
 


### PR DESCRIPTION
**What is is PR for?**

- [x] Code update
- [ ] Documentation update
- [ ] Infrastructure update

**What does this PR do?**  
Updated outdated default_envs `local_ttgo_t_beam` to `local_ttgo_lora32_v1` and `prod_ttgo_t_beam` to `prod_ttgo_lora32_v1` across all example `platformio.ini`

**Is this related to an open issue?**  
https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/issues/454

**Testing methodology**  
PR was built without any errors

**Additional context**  
Add any other technical detail or considerations here.

**Checklist**
Before you submit this pull request, please make sure you have done the following:

_General_  

- [x] Contribution Guidelines: Have you read the contribution guidelines?
- [x] Code of Conduct: Have you read the code of conduct?
- [x] Documentation: If applicable, have you added or updated all relevant documentation?

_For Code Updates_  

- [ ] Hardware Validation: If relevant, have you validated your changes on actual supported Duck hardware?
- [ ] Unit Tests: Have you run the unit tests on the device?
- [ ] Network Testing: If applicable, have you tested your changes on a Duck network?
- [ ] Licensing: Have you added a copyright and license header to each new file?

_Tested Targets (Please check all that apply)_

- [ ] All
- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] Heltec CubeCell Series
- [ ] TTGO T-Beam (SX1262)
- [ ] Others
