### PR TITLE
added threshold for "low signal"

### DIFF
--- a/examples/Basic-Ducks/DetectorDuck/DetectorDuck.ino
+++ b/examples/Basic-Ducks/DetectorDuck/DetectorDuck.ino
@@ -37,14 +37,11 @@ DuckDetect duck;
 // Create a timer with default settings
 auto timer = timer_create_default();
 
-const int INTERVAL_MS = 3000;
+const int INTERVAL_MS = 5000;
 
 void setup() {
-  // We are using a hardcoded device id here, but it should be retrieved or
-  // given during the device provisioning then converted to a byte vector to
-  // setup the duck NOTE: The Device ID must be exactly 8 bytes otherwise it
-  // will get rejected
-  std::string deviceId("DETECTOR");
+
+  std::string deviceId("DETECTOR"); // NOTE: The Device ID must be exactly 8 bytes
   std::vector<byte> devId;
   devId.insert(devId.end(), deviceId.begin(), deviceId.end());
   duck.setupWithDefaults(devId);
@@ -56,6 +53,7 @@ void setup() {
   // and will trigger sending a counter message.
   timer.every(INTERVAL_MS, pingHandler);
 
+  // Setup the LED
   FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalSMD5050 );
   FastLED.setBrightness(  BRIGHTNESS );
   leds[0] = CRGB::Gold;
@@ -65,7 +63,7 @@ void setup() {
 }
 
 void handleReceiveRssi(const int rssi) {
-  Serial.print("rssi callback called");
+  Serial.print("[DETECTOR] RSSI callback called");
   showSignalQuality(rssi);
 }
 
@@ -85,26 +83,26 @@ bool pingHandler(void *) {
 // But you can use a display, sound or LEDs
 void showSignalQuality(int incoming) {
   int rssi = incoming;
-  Serial.print("[DETECTOR] Rssi value: ");
+  Serial.print("[DETECTOR] RSSI value: ");
   Serial.print(rssi);
 
   if (rssi > -95) {
-    Serial.println(" - GOOD");
+    Serial.println(" - GOOD SIGNAL");
     leds[0] = CRGB::Green;
     FastLED.show();
   }
   else if (rssi <= -95 && rssi > -108) {
-    Serial.println(" - OKAY");
-    leds[0] = CRGB::Yellow;
+    Serial.println(" - OKAY SIGNAL");
+    leds[0] = CRGB::Blue;
     FastLED.show();
   }
-  else if (rssi <= -108) {
-    Serial.println(" - BAD");
-    Serial.println(" - BAD");
-    leds[0] = CRGB::Orange;
+  else if (rssi <= -108 <= -118) {
+    Serial.println(" - LOW SIGNAL");
+    leds[0] = CRGB::Purple;
     FastLED.show();
   }
   else {
+    Serial.println(" - NO SIGNAL");
     leds[0] = CRGB::Red;
     FastLED.show();
   }


### PR DESCRIPTION
**What is is PR for?**

- [X] Code update
- [ ] Documentation update
- [ ] Infrastructure update

**What does this PR do?**  
A bottom threshold for the detector duck was added for low signal. We want to have a little cushion for the low signal to add the next node. 

**Is this related to an open issue?**  
No

**Testing methodology**  
Upload two MamaDucks and a DetectorDuck. Deploy a MamaDuck and then turn on a DetectorDuck. Walk away from the MamaDuck with the DetectorDuck and check to see if the light turns from Green -> Blue -> Purple -> Red. 

**Additional context**  
Add any other technical detail or considerations here.

**Checklist**
Before you submit this pull request, please make sure you have done the following:

_General_  

- [X] Contribution Guidelines: Have you read the contribution guidelines?
- [X] Code of Conduct: Have you read the code of conduct?
- [X] Documentation: If applicable, have you added or updated all relevant documentation?

_For Code Updates_  

- [X] Hardware Validation: If relevant, have you validated your changes on actual supported Duck hardware?
- [ ] Unit Tests: Have you run the unit tests on the device?
- [ ] Network Testing: If applicable, have you tested your changes on a Duck network?
- [ ] Licensing: Have you added a copyright and license header to each new file?

_Tested Targets (Please check all that apply)_

- [X] All
- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] Heltec CubeCell Series
- [ ] TTGO T-Beam (SX1262)
- [ ] Others
