### PR TITLE
Ignore pongs

### DIFF
--- a/examples/Basic-Ducks/DetectorDuck/DetectorDuck.ino
+++ b/examples/Basic-Ducks/DetectorDuck/DetectorDuck.ino
@@ -38,6 +38,8 @@ DuckDetect duck;
 auto timer = timer_create_default();
 
 const int INTERVAL_MS = 5000;
+const unsigned long SIGNAL_TIMEOUT_MS = INTERVAL_MS + 1000; // 5 seconds timeout
+unsigned long lastSignalTime = 0;
 
 void setup() {
 
@@ -63,13 +65,23 @@ void setup() {
 }
 
 void handleReceiveRssi(const int rssi) {
-  Serial.print("[DETECTOR] RSSI callback called");
+  Serial.println("[DETECTOR] RSSI callback called");
   showSignalQuality(rssi);
+  Serial.println("[DETECTOR] Reseting signal timeout");
+  lastSignalTime = millis();
 }
 
 void loop() {
   timer.tick();
   duck.run(); // use internal duck detect behavior
+  
+  // Check if signal timeout occurred
+  if (millis() - lastSignalTime > SIGNAL_TIMEOUT_MS) {
+    Serial.println("[DETECTOR] No signal");
+    leds[0] = CRGB::Red;
+    FastLED.show();
+    lastSignalTime = millis(); // Reset to prevent continuous messages
+  }
 }
 
 // Periodically sends a ping message

--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -50,7 +50,7 @@ description = DetectorDuck CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip  ; CDP from master branch
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/src/Ducks/DuckDetect.cpp
+++ b/src/Ducks/DuckDetect.cpp
@@ -74,7 +74,7 @@ void DuckDetect::handleReceivedPacket() {
 }
 
 void DuckDetect::sendPing() {
-  Serial.println(String("send ping actually called from detector"));
+  loginfo("Sending PING...");
   int err = DUCK_ERR_NONE;
   std::vector<byte> data(1, 0);
   err = txPacket->prepareForSending(&filter, BROADCAST_DUID, DuckType::DETECTOR, reservedTopic::ping, data);

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -86,7 +86,7 @@ void MamaDuck::handleReceivedPacket() {
     if (duckutils::isEqual(BROADCAST_DUID, packet.dduid)) {
       switch(packet.topic) {
         case reservedTopic::ping:
-          loginfo_ln("PING received");
+          loginfo_ln("PING received. Sending PONG!");
           err = sendPong();
           if (err != DUCK_ERR_NONE) {
             logerr_ln("ERROR failed to send pong message. rc = %d",err);
@@ -94,7 +94,7 @@ void MamaDuck::handleReceivedPacket() {
           return;
         break;
         case reservedTopic::pong:
-          loginfo_ln("PONG received");
+          loginfo_ln("PONG received. Ignoring!");
           return;
         break;
         case reservedTopic::ack:{

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -95,7 +95,6 @@ void MamaDuck::handleReceivedPacket() {
         break;
         case reservedTopic::pong:
           loginfo_ln("PONG received. Ignoring!");
-          return;
         break;
         case reservedTopic::ack:{
           handleAck(packet);

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -86,11 +86,15 @@ void MamaDuck::handleReceivedPacket() {
     if (duckutils::isEqual(BROADCAST_DUID, packet.dduid)) {
       switch(packet.topic) {
         case reservedTopic::ping:
-          loginfo_ln("ping received");
+          loginfo_ln("PING received");
           err = sendPong();
           if (err != DUCK_ERR_NONE) {
             logerr_ln("ERROR failed to send pong message. rc = %d",err);
           }
+          return;
+        break;
+        case reservedTopic::pong:
+          loginfo_ln("PONG received");
           return;
         break;
         case reservedTopic::ack:{

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -100,7 +100,7 @@ void PapaDuck::handleReceivedPacket() {
   }
   
   if (data[TOPIC_POS] == reservedTopic::ping) {
-    logdbg_ln("PING received. Sending PONG!");
+    loginfo_ln("PING received. Sending PONG!");
     err = sendPong();
     if (err != DUCK_ERR_NONE) {
       logerr_ln("ERROR failed to send pong message. rc = %d",err);
@@ -109,7 +109,7 @@ void PapaDuck::handleReceivedPacket() {
   }
   
   if (data[TOPIC_POS] == reservedTopic::pong) {
-    logdbg_ln("PONG received. Ignoring!");
+    loginfo_ln("PONG received. Ignoring!");
     return;
   }
   

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -98,13 +98,21 @@ void PapaDuck::handleReceivedPacket() {
     logerr_ln("ERROR handleReceivedPacket. Failed to get data. rc = %d",err);
     return;
   }
-  // ignore pings
+  
   if (data[TOPIC_POS] == reservedTopic::ping) {
+    logdbg_ln("PING received. Sending PONG!");
     err = sendPong();
     if (err != DUCK_ERR_NONE) {
       logerr_ln("ERROR failed to send pong message. rc = %d",err);
     }
+    return;
   }
+  
+  if (data[TOPIC_POS] == reservedTopic::pong) {
+    logdbg_ln("PONG received. Ignoring!");
+    return;
+  }
+  
   // build our RX DuckPacket which holds the updated path in case the packet is relayed
   bool relay = rxPacket->prepareForRelaying(&filter, data);
   if (relay) {

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -105,31 +105,27 @@ void PapaDuck::handleReceivedPacket() {
     if (err != DUCK_ERR_NONE) {
       logerr_ln("ERROR failed to send pong message. rc = %d",err);
     }
-    return;
-  }
-  
-  if (data[TOPIC_POS] == reservedTopic::pong) {
+  } else if (data[TOPIC_POS] == reservedTopic::pong) {
     loginfo_ln("PONG received. Ignoring!");
-    return;
-  }
-  
-  // build our RX DuckPacket which holds the updated path in case the packet is relayed
-  bool relay = rxPacket->prepareForRelaying(&filter, data);
-  if (relay) {
-    logdbg_ln("relaying:  %s", duckutils::convertToHex(rxPacket->getBuffer().data(), rxPacket->getBuffer().size()).c_str());
-    loginfo_ln("invoking callback in the duck application...");
-    
-    recvDataCallback(rxPacket->getBuffer());
-    
-    if (acksEnabled) {
-      const CdpPacket packet = CdpPacket(rxPacket->getBuffer());
-      if (needsAck(packet)) {
-        handleAck(packet);
+  } else {
+    // build our RX DuckPacket which holds the updated path in case the packet is relayed
+    bool relay = rxPacket->prepareForRelaying(&filter, data);
+    if (relay) {
+      logdbg_ln("relaying:  %s", duckutils::convertToHex(rxPacket->getBuffer().data(), rxPacket->getBuffer().size()).c_str());
+      loginfo_ln("invoking callback in the duck application...");
+      
+      recvDataCallback(rxPacket->getBuffer());
+      
+      if (acksEnabled) {
+        const CdpPacket packet = CdpPacket(rxPacket->getBuffer());
+        if (needsAck(packet)) {
+          handleAck(packet);
+        }
       }
     }
-
-    loginfo_ln("handleReceivedPacket() DONE");
   }
+
+  loginfo_ln("handleReceivedPacket() DONE");
 }
 
 void PapaDuck::handleAck(const CdpPacket & packet) {


### PR DESCRIPTION
**What is is PR for?**

- [X] Code update
- [ ] Documentation update
- [ ] Infrastructure update

**What does this PR do?**  
Ducks respond to DetectorDuck's pings using a Pong. The pong should be ignored by all the Ducks except for the DetectorDuck. At the moment, the MamaDucks relay pongs and the PapaDuck uploads the pong to the cloud. This PR makes sure that the PapaDuck and MamaDuck ignores those pongs. Also a timer for signal lost was added to the Detector Duck to turn red if there are no pongs.

**Is this related to an open issue?**  
No.

**Testing methodology**  
Upload a standard mesh network (PapaDuck, MamaDuck) and a DetectorDuck. The DetectorDuck should turn colors based on the RSSI values, while the MamaDuck and PapaDuck should be sending PINGs but ignoring PONGs.

**Additional context**  
Add any other technical detail or considerations here.

**Checklist**
Before you submit this pull request, please make sure you have done the following:

_General_  

- [X] Contribution Guidelines: Have you read the contribution guidelines?
- [X] Code of Conduct: Have you read the code of conduct?
- [X] Documentation: If applicable, have you added or updated all relevant documentation?

_For Code Updates_  

- [X] Hardware Validation: If relevant, have you validated your changes on actual supported Duck hardware?
- [ ] Unit Tests: Have you run the unit tests on the device?
- [X] Network Testing: If applicable, have you tested your changes on a Duck network?
- [ ] Licensing: Have you added a copyright and license header to each new file?

_Tested Targets (Please check all that apply)_

- [ ] All
- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] Heltec CubeCell Series
- [X] TTGO T-Beam (SX1262)
- [ ] Others
