### PR TITLE
Release 4.3.0

### DIFF
--- a/examples/Basic-Ducks/DuckLink/platformio.ini
+++ b/examples/Basic-Ducks/DuckLink/platformio.ini
@@ -49,7 +49,7 @@ description = DuckLink CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Basic-Ducks/MamaDuck/platformio.ini
+++ b/examples/Basic-Ducks/MamaDuck/platformio.ini
@@ -49,7 +49,7 @@ description = MamaDuck CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Basic-Ducks/PapaDuck/platformio.ini
+++ b/examples/Basic-Ducks/PapaDuck/platformio.ini
@@ -49,7 +49,7 @@ description = PapaDuck CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Detect/platformio.ini
@@ -31,7 +31,7 @@ description = Custom Mama Detect examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 ; -------------------------------------------------------------------------------------------------------      
 ; ---- PRODUCTION ENVIRONMENTS

--- a/examples/Custom-Mama-Examples/Custom-Mama-Example/Custom-Mama-Example.ino
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Example/Custom-Mama-Example.ino
@@ -43,8 +43,8 @@ void setup() {
   // The Device ID must be unique and 8 bytes long. Typically the ID is stored
   // in a secure nvram, or provided to the duck during provisioning/registration
   std::string deviceId("MAMA0001");
-  std::vector<byte> devId;
-  devId.insert(devId.end(), deviceId.begin(), deviceId.end()); 
+  std::array<byte,8> devId;
+  std::copy(deviceId.begin(), deviceId.end(), devId.begin());
 
 
   //Set the Device ID

--- a/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
+++ b/examples/Custom-Mama-Examples/Custom-Mama-Example/platformio.ini
@@ -30,7 +30,7 @@ description = Custom Mama examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 ; -------------------------------------------------------------------------------------------------------      
 ; ---- PRODUCTION ENVIRONMENTS

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
@@ -144,8 +144,8 @@ int quackJson(CdpPacket packet) {
 
   Serial.printf("[PAPA] muid:    %s\n" , muid.c_str());
   Serial.printf("[PAPA] data:    %s\n" , payload.c_str());
-  Serial.printf("[PAPA] hops:    %s\n", packet.hopCount);
-  Serial.printf("[PAPA] duck:    %s\n" , packet.duckType);
+  Serial.printf("[PAPA] hops:    %s\n", String(packet.hopCount));
+  Serial.printf("[PAPA] duck:    %s\n" , String(packet.duckType));
 
   doc["DeviceID"] = sduid;
   doc["MessageID"] = muid;

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
@@ -211,8 +211,8 @@ void setup() {
   
   // NOTE: The Device ID must be exactly 8 bytes otherwise it will get rejected
   std::string deviceId("PAPADUCK");
-  std::vector<byte> devId;
-  devId.insert(devId.end(), deviceId.begin(), deviceId.end());
+  std::array<byte,8> devId;
+  std::copy(deviceId.begin(), deviceId.end(), devId.begin());
 
   // the default setup is equivalent to the above setup sequence
   duck.setupWithDefaults(devId, SSID, PASSWORD);
@@ -271,7 +271,7 @@ void loop() {
 void gotMsg(char* topic, byte* payload, unsigned int payloadLength) {
   Serial.print("gotMsg: invoked for topic: "); Serial.println(topic);
 
-  if (std::string(topic).indexOf(CMD_STATE_WIFI) > 0) {
+  if (std::string(topic).find(CMD_STATE_WIFI) > 0) {
     Serial.println("Start WiFi Command");
     byte sCmd = 1;
     std::vector<byte> sValue = {payload[0]};

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
@@ -49,7 +49,7 @@ description = AWS PapaDuck CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 
 ; -------------------------------------------------------------------------------------------------------      

--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/platformio.ini
@@ -42,7 +42,7 @@ description = AWS PapaDuck CDP examples
       bblanchon/ArduinoJson@^7.0.3
 
 [env:esp32]
-   lib_deps = 
+   lib_deps = knolleary/pubsubclient@^2.8.0
 
 [env:local_cdp]
    lib_deps = symlink://../../../ ; local CDP library      

--- a/examples/Custom-Papa-Examples/MQTT-PapaDuck/MQTT-PapaDuck.ino
+++ b/examples/Custom-Papa-Examples/MQTT-PapaDuck/MQTT-PapaDuck.ino
@@ -285,8 +285,8 @@ void handleDuckData(std::vector<byte> packetBuffer) {
 
 void setup() {
   std::string deviceId("PAPA0001");
-  std::vector<byte> devId;
-  devId.insert(devId.end(), deviceId.begin(), deviceId.end());
+  std::array<byte,8> devId;
+  std::copy(deviceId.begin(), deviceId.end(), devId.begin());
   
   // Set the CA cert for the WiFi client
   wifiClient.setCACert(mosquitto_ca_cert);

--- a/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
+++ b/examples/Custom-Papa-Examples/MQTT-PapaDuck/platformio.ini
@@ -30,7 +30,7 @@ description = Papa MQTT CDP examples
 
 [env:release_cdp]
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
 
 ; -------------------------------------------------------------------------------------------------------      
 ; ---- PRODUCTION ENVIRONMENTS

--- a/examples/External-Boards-Example/DuckLink/DuckLink.ino
+++ b/examples/External-Boards-Example/DuckLink/DuckLink.ino
@@ -10,9 +10,9 @@ DuckLink duck;
 void setup()
 {
     std::string deviceId("LINK0001");
-    std::vector<byte> devId;
+    std::array<byte,8> devId;
+    std::copy(deviceId.begin(), deviceId.end(), devId.begin());
     int rc;
-    devId.insert(devId.end(), deviceId.begin(), deviceId.end());
     rc = duck.setupWithDefaults(devId);
 
     loginfo_ln("Hello, World!");

--- a/examples/External-Boards-Example/DuckLink/my-boards/heltec-cubecell-gps/pio_cubecell_gps.ini
+++ b/examples/External-Boards-Example/DuckLink/my-boards/heltec-cubecell-gps/pio_cubecell_gps.ini
@@ -9,7 +9,7 @@
   lib_deps = 
       WIRE
       SPI
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
       contrem/arduino-timer@^3.0.1
       bblanchon/ArduinoJson@^7.0.3  
 

--- a/examples/External-Boards-Example/DuckLink/my-boards/heltec-wireless-paper/pio_wireless_paper.ini
+++ b/examples/External-Boards-Example/DuckLink/my-boards/heltec-wireless-paper/pio_wireless_paper.ini
@@ -5,7 +5,7 @@
    monitor_speed = 115200
    monitor_filters = time
    lib_deps = 
-      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.2.0.zip
+      https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.3.0.zip
       WIRE
       SPI
       ARDUINOOTA

--- a/library.json
+++ b/library.json
@@ -37,7 +37,6 @@
         "bakercp/CRC32": "2.0.0",
         "jgromes/RadioLib": "^7.1.2",
         "operatorfoundation/Crypto": "^0.4.0",
-        "me-no-dev/AsyncTCP": "^1.1.1",
         "mathieucarbou/ESP Async WebServer": "^2.7.0",
         "knolleary/pubsubclient":"^2.8.0",
         "mikalhart/TinyGPSPlus": "~1.0.2"

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
         "url": "https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol"
     },
     "frameworks": "arduino",
-    "platforms": ["espressif32"], 
+    "platforms": ["espressif32@3.6.1"], 
     "license": "Apache-2.0",
     "export": {
         "include": [

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
         "email": "info@owlintegrations.com",
         "url": "https://owlintegrations.com/"
     },
-    "version": "4.2.0",
+    "version": "4.3.0",
     "repository":
     {
         "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=The ClusterDuck Protocol is an open-source project under The Linux Fou
 category=Communication
 url=https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol
 architectures=*
-depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Crypto,AsyncTCP,ESP Async WebServer,PubSubClient,TinyGPSPlus
+depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Crypto,AsyncTCP@1.1.1,ESP Async WebServer@2.7.0,PubSubClient,TinyGPSPlus
 includes=CDP.h

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=The ClusterDuck Protocol is an open-source project under The Linux Fou
 category=Communication
 url=https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol
 architectures=*
-depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Crypto,AsyncTCP,ESP Async WebServer,PubSubClient,TinyGPSPlus
+depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Crypto,Async TCP,ESP Async WebServer,PubSubClient,TinyGPSPlus
 includes=CDP.h

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ClusterDuck Protocol
-version=4.2.0
+version=4.3.0
 author=OWL Integrations <info@owlintegrations.com>
 maintainer=OWL Integrations <info@owlintegrations.com>
 sentence=Mesh communication protocol.

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=The ClusterDuck Protocol is an open-source project under The Linux Fou
 category=Communication
 url=https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol
 architectures=*
-depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Crypto,AsyncTCP@1.1.1,ESP Async WebServer@2.7.0,PubSubClient,TinyGPSPlus
+depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Crypto,AsyncTCP,ESP Async WebServer,PubSubClient,TinyGPSPlus
 includes=CDP.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -87,7 +87,7 @@
     -DRADIOLIB_EXCLUDE_LLCC68
 
 [env:esp32_base]
-  platform = espressif32
+  platform = espressif32@3.6.1
   board = esp32dev
   framework = arduino
   lib_deps =

--- a/src/DuckDisplay.cpp
+++ b/src/DuckDisplay.cpp
@@ -102,7 +102,7 @@ DuckDisplay* DuckDisplay::getInstance() {
 
 #ifndef CDPCFG_OLED_NONE
 
-void DuckDisplay::setupDisplay(int duckType, std::vector<byte> name) {
+void DuckDisplay::setupDisplay(int duckType, std::array<byte,8> name) {
   u8g2.begin();        // clear the internal memory
   u8g2.setFont(u8g2_font_synchronizer_nbp_tf); // choose a suitable font
   u8g2.clearBuffer();  

--- a/src/DuckDisplay.h
+++ b/src/DuckDisplay.h
@@ -38,7 +38,7 @@ public:
    */
   static DuckDisplay* getInstance();
 #ifdef CDPCFG_OLED_NONE
-  void setupDisplay(int duckType, std::vector<byte> name) {}
+  void setupDisplay(int duckType, std::array<byte,8> name) {}
   void powerSave(bool save) {}
   void drawString(uint8_t x, uint8_t y, const char* text) {}
   void drawString(bool cls, uint8_t x, uint8_t y, const char* text) {}
@@ -55,7 +55,7 @@ public:
    * @brief Initialize the display component.
    * 
    */
-  void setupDisplay(int duckType, std::vector<byte> name);
+  void setupDisplay(int duckType, std::array<byte,8> name);
   /**
    * @brief Toggle the display in or out of power saving mode.
    * 

--- a/src/include/cdpcfg.h
+++ b/src/include/cdpcfg.h
@@ -23,7 +23,7 @@
 
 // version definitions
 #define CDP_VERSION_MAJOR  4
-#define CDP_VERSION_MINOR  2
+#define CDP_VERSION_MINOR  3
 #define CDP_VERSION_PATCH  0
 
 #define CDP_VERSION ((((CDP_VERSION_MAJOR) << 16) | ((CDP_VERSION_MINOR) << 8) | (CDP_VERSION_PATCH)))


### PR DESCRIPTION
Final testing and bug fixes for CDP v4.3.0 release. Changes made in this release:

* GPS support  through TinyGPS++
* Updates for RadioLib v7
* Fixes for various example sketches
* Remove Cubecell Support
* Replacing Arduino String with std::string and byte vectors with STL containers
* Fixes to the Captive Portal

_Tested Targets (Please check all that apply)_
- [x] Heltec LoRa v3
- [x] Heltec LoRa v2
- [x] T-Beam SoftRF sX1262
- [x] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)

_Full Network Test_
For the full network test, set up 

1. an AWS Papa or mqtt Papa
2. Two Mama Ducks, one using cdp v4.2.0 and one using local
3. one duck link
4. Test a detector duck with each of the 4 other ducks above

Make sure to use different device types if you can!

- [x] Full Network Test
- [x] Hop Test