### PR TITLE
changed to std::to_string

### DIFF
--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
@@ -9,7 +9,7 @@
  * try to publish all messages in the queue. You can change the size of the queue
  * by changing `QUEUE_SIZE_MAX`.
  *
- * @date 06-14-2024
+ * @date 04-04-2025
  *
  */
 
@@ -144,8 +144,8 @@ int quackJson(CdpPacket packet) {
 
   Serial.printf("[PAPA] muid:    %s\n" , muid.c_str());
   Serial.printf("[PAPA] data:    %s\n" , payload.c_str());
-  Serial.printf("[PAPA] hops:    %s\n", String(packet.hopCount));
-  Serial.printf("[PAPA] duck:    %s\n" , String(packet.duckType));
+  Serial.printf("[PAPA] hops:    %s\n", std::to_string(packet.hopCount));
+  Serial.printf("[PAPA] duck:    %s\n" , std::to_string(packet.duckType));
 
   doc["DeviceID"] = sduid;
   doc["MessageID"] = muid;
@@ -154,13 +154,6 @@ int quackJson(CdpPacket packet) {
   doc["duckType"].set(packet.duckType);
 
   std::string cdpTopic = toTopicString(packet.topic);
-  
-  // display->clear();
-  // display->drawString(0, 10, "New Message");
-  // display->drawString(0, 20, sduid.c_str());
-  // display->drawString(0, 30, muid.c_str());
-  // display->drawString(0, 40, cdpTopic.c_str());
-  // display->sendBuffer();
 
   std::string topic = "owl/device/" + std::string(THINGNAME) + "/evt/" + cdpTopic;
 


### PR DESCRIPTION
**Affected Areas:**

- [X] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
There were a couple of `String` in AWS Papa. I converted it to `std::to_string`

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [ ] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
