### PR TITLE
Get Duck Name

### DIFF
--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -14,7 +14,7 @@ Duck::Duck(std::string name):
   filter(), // initialized filter with default values
   duckNet(new DuckNet(&filter))
 {
-  // duckName = name;
+  
 }
 
 Duck::~Duck() {

--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -69,7 +69,7 @@ void Duck::logIfLowMemory() {
 }
 
 int Duck::setDeviceId(std::array<byte,8>& id) {
-    std::copy(id.begin(), id.end(),duid.begin());
+  std::copy(id.begin(), id.end(),duid.begin());
   loginfo_ln("setupDeviceId rc = %d",DUCK_ERR_NONE);
   return DUCK_ERR_NONE;
 }

--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -14,7 +14,7 @@ Duck::Duck(std::string name):
   filter(), // initialized filter with default values
   duckNet(new DuckNet(&filter))
 {
-  duckName = name;
+  // duckName = name;
 }
 
 Duck::~Duck() {

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -42,6 +42,7 @@ public:
    * @returns A string representing the duck's name
    */
   std::string getName() {return duckName;}
+
   /**
    * @brief setup the duck unique ID
    * 
@@ -49,6 +50,13 @@ public:
    * @return DUCK_ERR_NONE if successful, an error code otherwise 
    */
   int setDeviceId(std::array<byte,8>& id);
+
+  /**
+   * @brief Get the duck's unique ID.
+   * 
+   * @returns A std::string representing the duck's unique ID
+   */ 
+  std::string getDuckId() {return std::string(duid.begin(), duid.end());}
 
   /**
    * @brief setup the duck unique ID

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -29,20 +29,6 @@ public:
 
   std::string getCDPVersion() { return duckutils::getCDPVersion(); }
 
-  // /**
-  //  * @brief Set the Device Name object
-  //  * 
-  //  * @param name 
-  //  */
-  // void setName(std::string name) { this->duckName = name; }
-  
-  // /**
-  //  * @brief Get the duck's name.
-  //  * 
-  //  * @returns A string representing the duck's name
-  //  */
-  // std::string getName() {return duckName;}
-
   /**
    * @brief setup the duck unique ID
    * 
@@ -295,8 +281,6 @@ public:
 protected:
   Duck(Duck const&) = delete;
   Duck& operator=(Duck const&) = delete;
-
-  // std::string duckName="";
 
   std::string deviceId;
   std::array<byte,8> duid;

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -29,19 +29,19 @@ public:
 
   std::string getCDPVersion() { return duckutils::getCDPVersion(); }
 
-  /**
-   * @brief Set the Device Name object
-   * 
-   * @param name 
-   */
-  void setName(std::string name) { this->duckName = name; }
+  // /**
+  //  * @brief Set the Device Name object
+  //  * 
+  //  * @param name 
+  //  */
+  // void setName(std::string name) { this->duckName = name; }
   
-  /**
-   * @brief Get the duck's name.
-   * 
-   * @returns A string representing the duck's name
-   */
-  std::string getName() {return duckName;}
+  // /**
+  //  * @brief Get the duck's name.
+  //  * 
+  //  * @returns A string representing the duck's name
+  //  */
+  // std::string getName() {return duckName;}
 
   /**
    * @brief setup the duck unique ID
@@ -296,7 +296,7 @@ protected:
   Duck(Duck const&) = delete;
   Duck& operator=(Duck const&) = delete;
 
-  std::string duckName="";
+  // std::string duckName="";
 
   std::string deviceId;
   std::array<byte,8> duid;


### PR DESCRIPTION
**Affected Areas:**

- [X] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
There are two instances that we set the name of the Duck: `duid` and `duckName`. At the moment, `duckName` is set to "" and the getter function to retrieve the name of the duck returns`duckName`. Therefore, I removed (commented out) duckName and made a getter function to retrieve `duid`. 

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [ ] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [X] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
