### PR TITLE
changed location of PubSub

### DIFF
--- a/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
+++ b/examples/Custom-Papa-Examples/AWS-PapaDuck/AWS-PapaDuck.ino
@@ -40,14 +40,12 @@
 // --- Global Objects ---
 PapaDuck duck;
 int QUEUE_SIZE_MAX = 5;
-std::queue<std::vector<byte>> packetQueue;
 auto timer = timer_create_default();
 bool retry = true; 
-WiFiClientSecure wifiClient;
-PubSubClient client(AWS_IOT_ENDPOINT, 8883, gotMsg, wifiClient);
 const char commandTopic[] = "iot-2/cmd/+/fmt/+";
 
 // --- Function Declarations ---
+std::queue<std::vector<byte>> packetQueue;
 std::string toTopicString(byte topic);
 std::string convertToHex(byte* data, int size);
 int quackJson(CdpPacket packet);
@@ -58,6 +56,10 @@ void mqttConnect();
 void subscribeTo(const char* topic);
 bool enableRetry(void*);
 void publishQueue();
+
+// --- WIFI Setup Function ---
+WiFiClientSecure wifiClient;
+PubSubClient client(AWS_IOT_ENDPOINT, 8883, gotMsg, wifiClient);
 
 /**
  * @brief Converts a CDP topic byte value into a string.


### PR DESCRIPTION
**Affected Areas:**

- [X] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
The `gotMsg` function was called before it was declared. Therefore I moved the call after it was declared.

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [ ] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
