### PR TITLE
Debug printout changes

### DIFF
--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -36,13 +36,13 @@ bool DuckPacket::prepareForRelaying(BloomFilter *filter, std::vector<byte> dataB
   
 }
 
-void DuckPacket::getUniqueMessageId(BloomFilter * filter, byte message_id[MUID_LENGTH]) {
+void DuckPacket::getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUID_LENGTH> &message_id) {
 
   bool getNewUnique = true;
   while (getNewUnique) {
-    duckutils::getRandomBytes(MUID_LENGTH, message_id);
-    getNewUnique = filter->bloom_check(message_id, MUID_LENGTH);
-    loginfo_ln("prepareForSending: new MUID -> %s",duckutils::convertToHex(message_id, MUID_LENGTH).c_str());
+    duckutils::getRandomBytes(MUID_LENGTH, message_id.data());
+    getNewUnique = filter->bloom_check(message_id.data(), MUID_LENGTH);
+    loginfo_ln("prepareForSending: new MUID -> %s",duckutils::convertToHex(message_id.data(), MUID_LENGTH).c_str());
   }
 }
 
@@ -61,7 +61,7 @@ int DuckPacket::prepareForSending(BloomFilter *filter,
 
   loginfo_ln("prepareForSending: DATA LENGTH: %d - TOPIC (%s)", app_data_length, CdpPacket::topicToString(topic).c_str());
 
-  byte message_id[MUID_LENGTH];
+  std::array<uint8_t,MUID_LENGTH> message_id;
   getUniqueMessageId(filter, message_id);
 
   byte crc_bytes[DATA_CRC_LENGTH];
@@ -80,33 +80,36 @@ int DuckPacket::prepareForSending(BloomFilter *filter,
   crc_bytes[3] = value & 0xFF;
 
   // ----- insert packet header  -----
+    loginfo_ln("prepareForSending: START");
+    std::string printStr;
   // source device uid
     buffer.insert(buffer.end(), duid.begin(), duid.end());
     logdbg_ln("SDuid:     %s",duckutils::convertToHex(duid.data(), duid.size()).c_str());
 
     // destination device uid
     buffer.insert(buffer.end(), targetDevice.begin(), targetDevice.end());
-    logdbg_ln("DDuid:     %s", duckutils::convertToHex(targetDevice.data(), targetDevice.size()).c_str());
-
+    printStr.assign(targetDevice.begin(), targetDevice.end());
+    logdbg_ln("DDuid:     %s", printStr.c_str());
     // message uid
     buffer.insert(buffer.end(), &message_id[0], &message_id[MUID_LENGTH]);
-    logdbg_ln("Muid:      %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+    printStr.assign(message_id.begin(), message_id.end());
+    logdbg_ln("Muid:      %s", printStr.c_str());
 
     // topic
     buffer.insert(buffer.end(), topic);
-    logdbg_ln("Topic:     %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+    logdbg_ln("Topic:     %s", CdpPacket::topicToString(topic).c_str());
 
     // duckType
     buffer.insert(buffer.end(), duckType);
-    logdbg_ln("duck type: %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+    logdbg_ln("duck type: %s", std::to_string(getBuffer().at(DUCK_TYPE_POS)).c_str());
 
     // hop count
     buffer.insert(buffer.end(), 0x00);
-    logdbg_ln("hop count: %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+    logdbg_ln("hop count: %s", std::to_string(getBuffer().at(HOP_COUNT_POS)).c_str());
 
     // data crc
     buffer.insert(buffer.end(), &crc_bytes[0], &crc_bytes[DATA_CRC_LENGTH]);
-    logdbg_ln("Data CRC:  %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+    logdbg_ln("Data CRC:  %s", printStr.assign(crc_bytes, crc_bytes + DATA_CRC_LENGTH).c_str());
 
     // ----- insert data -----
     if(duckcrypto::getState()) {
@@ -116,11 +119,12 @@ int DuckPacket::prepareForSending(BloomFilter *filter,
 
     } else {
         buffer.insert(buffer.end(), app_data.begin(), app_data.end());
-        logdbg_ln("Data:      %s",duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+        //convert the data to string for logging
+        logdbg_ln("Data:      %s",printStr.assign(app_data.begin(), app_data.end()).c_str());
     }
-
-    logdbg_ln("Built packet: %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
     getBuffer().shrink_to_fit();
+    logdbg_ln("Built packet (HEX): %s", duckutils::convertToHex(buffer.data(), buffer.size()).c_str());
+
   return DUCK_ERR_NONE;
 }
 

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -64,7 +64,7 @@ int DuckPacket::prepareForSending(BloomFilter *filter,
   std::array<uint8_t,MUID_LENGTH> message_id;
   getUniqueMessageId(filter, message_id);
 
-  byte crc_bytes[DATA_CRC_LENGTH];
+  std::array<uint8_t,DATA_CRC_LENGTH> crc_bytes;
   uint32_t value;
   // TODO: update the CRC32 library to return crc as a byte array
   if(duckcrypto::getState()) {
@@ -109,7 +109,7 @@ int DuckPacket::prepareForSending(BloomFilter *filter,
 
     // data crc
     buffer.insert(buffer.end(), &crc_bytes[0], &crc_bytes[DATA_CRC_LENGTH]);
-    logdbg_ln("Data CRC:  %s", printStr.assign(crc_bytes, crc_bytes + DATA_CRC_LENGTH).c_str());
+    logdbg_ln("Data CRC:  %s", duckutils::convertToHex(crc_bytes.data(), DATA_CRC_LENGTH).c_str());
 
     // ----- insert data -----
     if(duckcrypto::getState()) {

--- a/src/include/DuckPacket.h
+++ b/src/include/DuckPacket.h
@@ -112,7 +112,7 @@ public:
   private: 
     std::array<byte,8> duid;
     std::vector<byte> buffer;
-    static void getUniqueMessageId(BloomFilter * filter, byte message_id[MUID_LENGTH]);
+    static void getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUID_LENGTH> &message_id);
 
 };
 


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
Quality of life changes to debug printouts in the `prepareForSending()` method. Also using std::array for two temp variables and a method call.

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [x] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [x] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
