### PR TITLE
discussed on discord, but the minus-1 change was still present.

### DIFF
--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -118,7 +118,7 @@ int DuckPacket::prepareForSending(BloomFilter *filter,
 
     // data crc
     buffer.insert(buffer.end(), crc_bytes.begin(), crc_bytes.end());
-    logdbg_ln("Data CRC:  %s", duckutils::convertToHex(crc_bytes.data(), DATA_CRC_LENGTH - 1).c_str());
+    logdbg_ln("Data CRC:  %s", duckutils::arrayToHexString(crc_bytes).c_str());
 
     // ----- insert data -----
     if(duckcrypto::getState()) {


### PR DESCRIPTION
Just putting in the correct call to get the hex string.

**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
There were a few things that went awry with a previous build that were solved, but this one thing got through. It's not supposed to be index-1, but the entire length.

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [x] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [x] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
