### PR TITLE
Fix PIO registry crawler

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
         "url": "https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol"
     },
     "frameworks": "arduino",
-    "platforms": ["espressif32@3.6.1"], 
+    "platforms": ["espressif32"], 
     "license": "Apache-2.0",
     "export": {
         "include": [


### PR DESCRIPTION
The PIO crawler wont work since we cant define specifric ESP32 versions in the library.json file