### PR TITLE
Changes away from byte

### DIFF
--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -111,7 +111,7 @@ int DuckNet::setupWebServer(bool createCaptivePortal, std::string html) {
     clientId = duckutils::toUpperCase(clientId); 
     val = "[" + clientId + "]" + val;
 
-    std::vector<byte> data;
+    std::vector<uint8_t> data;
     data.insert(data.end(), val.begin(), val.end());
     //TODO: send the correct ducktype. Probably need the ducktype when DuckNet is created or setup
     txPacket->prepareForSending(bloomFilter, ZERO_DUID, DuckType::UNKNOWN, topics::cpm, data );

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -71,8 +71,8 @@ ArduinoJson::JsonDocument DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument rreq,
 }
 
 int DuckPacket::prepareForSending(BloomFilter *filter,
-                                  std::array<byte,8> targetDevice, byte duckType,
-                                  byte topic, std::vector<uint8_t> app_data) {
+                                  std::array<uint8_t ,8> targetDevice, uint8_t duckType,
+                                  uint8_t topic, std::vector<uint8_t> app_data) {
 
   std::vector<uint8_t> encryptedData;
   uint8_t app_data_length = app_data.size();

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 
-bool DuckPacket::prepareForRelaying(BloomFilter *filter, std::vector<byte> dataBuffer) {
+bool DuckPacket::prepareForRelaying(BloomFilter *filter, std::vector<uint8_t> dataBuffer) {
 
 
   this->reset();
@@ -46,7 +46,7 @@ void DuckPacket::getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUI
   }
 }
 
-ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<byte,8> targetDevice, std::array<uint8_t,8> sourceDevice) {
+ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t,8> sourceDevice) {
     ArduinoJson::JsonObject rreq = ArduinoJson::JsonObject();
     rreq["origin"] = duckutils::convertToHex(sourceDevice.data(), sourceDevice.size());
     rreq["path"] = ArduinoJson::JsonArray();

--- a/src/DuckRadio.cpp
+++ b/src/DuckRadio.cpp
@@ -142,7 +142,7 @@ int DuckRadio::setupRadio(LoraConfigParams config) {
     return DUCK_ERR_NONE;
 }
 
-int DuckRadio::setSyncWord(byte syncWord) {
+int DuckRadio::setSyncWord(uint8_t syncWord) {
     if (!isSetup) {
         logerr_ln("ERROR  LoRa radio not setup");
         return DUCKLORA_ERR_NOT_INITIALIZED;
@@ -163,7 +163,7 @@ int DuckRadio::goToReceiveMode(bool clearReceiveFlag) {
     return startReceive();
 }
 
-int DuckRadio::readReceivedData(std::vector<byte>* packetBytes) {
+int DuckRadio::readReceivedData(std::vector<uint8_t>* packetBytes) {
 
     int packet_length = 0;
     int err = DUCK_ERR_NONE;
@@ -232,7 +232,7 @@ int DuckRadio::readReceivedData(std::vector<byte>* packetBytes) {
     return err;
 }
 
-int DuckRadio::sendData(byte* data, int length)
+int DuckRadio::sendData(uint8_t* data, int length)
 {
 
     if (!isSetup) {
@@ -473,7 +473,7 @@ void DuckRadio::onInterrupt(void) {
     interruptFlags = lora.getIrqFlags();
 }
 
-int DuckRadio::startTransmitData(byte* data, int length) {
+int DuckRadio::startTransmitData(uint8_t* data, int length) {
     int err = DUCK_ERR_NONE;
     int tx_err = RADIOLIB_ERR_NONE;
 

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -58,7 +58,7 @@ void MamaDuck::run() {
 
 void MamaDuck::handleReceivedPacket() {
 
-  std::vector<byte> data;
+  std::vector<uint8_t> data;
   bool relay = false;
   
   loginfo_ln("====> handleReceivedPacket: START");
@@ -116,7 +116,7 @@ void MamaDuck::handleReceivedPacket() {
           }
       }
     } else if(duckutils::isEqual(duid, packet.dduid)) { //Target device check
-        std::vector<byte> dataPayload;
+        std::vector<uint8_t> dataPayload;
         byte num = 1;
       
       switch(packet.topic) {
@@ -154,8 +154,8 @@ void MamaDuck::handleReceivedPacket() {
 
 void MamaDuck::handleCommand(const CdpPacket & packet) {
   int err;
-  std::vector<byte> dataPayload;
-  std::vector<byte> alive {'I','m',' ','a','l','i','v','e'};
+  std::vector<uint8_t> dataPayload;
+  std::vector<uint8_t> alive {'I','m',' ','a','l','i','v','e'};
 
   switch(packet.data[0]) {
     case 0:

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -122,7 +122,7 @@ void PapaDuck::handleReceivedPacket() {
 
 void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value) {
   loginfo_ln("Initiate sending command");
-  std::vector<byte> dataPayload;
+  std::vector<uint8_t> dataPayload;
   dataPayload.push_back(cmd);
   dataPayload.insert(dataPayload.end(), value.begin(), value.end());
 
@@ -143,7 +143,7 @@ void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value) {
   }
 }
 
-void PapaDuck::sendCommand(byte cmd, std::vector<uint8_t> value, std::array<uint8_t,8> dduid) {
+void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value, std::array<uint8_t,8> dduid) {
   loginfo_ln("Initiate sending command");
   std::vector<byte> dataPayload;
   dataPayload.push_back(cmd);

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -1,6 +1,6 @@
 #include "../PapaDuck.h"
 #include <cassert>
-int PapaDuck::setupWithDefaults(std::array<byte,8> deviceId, std::string ssid, std::string password) {
+int PapaDuck::setupWithDefaults(std::array<uint8_t,8> deviceId, std::string ssid, std::string password) {
   loginfo_ln("setupWithDefaults...");
 
   int err = Duck::setupWithDefaults(deviceId, ssid, password);
@@ -90,7 +90,7 @@ void PapaDuck::run() {
 void PapaDuck::handleReceivedPacket() {
 
   loginfo_ln("handleReceivedPacket() START");
-  std::vector<byte> data;
+  std::vector<uint8_t> data;
   int err = duckRadio.readReceivedData(&data);
 
   if (err != DUCK_ERR_NONE) {
@@ -120,7 +120,7 @@ void PapaDuck::handleReceivedPacket() {
   loginfo_ln("handleReceivedPacket() DONE");
 }
 
-void PapaDuck::sendCommand(byte cmd, std::vector<byte> value) {
+void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value) {
   loginfo_ln("Initiate sending command");
   std::vector<byte> dataPayload;
   dataPayload.push_back(cmd);
@@ -143,7 +143,7 @@ void PapaDuck::sendCommand(byte cmd, std::vector<byte> value) {
   }
 }
 
-void PapaDuck::sendCommand(byte cmd, std::vector<byte> value, std::array<byte,8> dduid) {
+void PapaDuck::sendCommand(byte cmd, std::vector<uint8_t> value, std::array<uint8_t,8> dduid) {
   loginfo_ln("Initiate sending command");
   std::vector<byte> dataPayload;
   dataPayload.push_back(cmd);

--- a/src/include/DuckPacket.h
+++ b/src/include/DuckPacket.h
@@ -98,7 +98,7 @@ public:
      * 
      * @returns a array of bytes representing the cdp packet
      */
-    std::vector<byte> getBuffer() { return buffer;}
+    std::vector<uint8_t> getBuffer() { return buffer;}
 
     /**
      * @brief Resets the packet byte buffer.


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
A brief description of changes made in this PR.
This is just cleaning up some usages of Arduino's `byte` typedef keyword I intended to go in as part of #496.

**Related Issues:**  
#496
**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [ ] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
