### PR TITLE
changes to DuckPacket

### DIFF
--- a/src/CdpPacket.h
+++ b/src/CdpPacket.h
@@ -143,29 +143,29 @@ DCRC:      04  byte value          - Data section CRC
 DATA:      229 byte array          - Data payload (e.g sensor read, text,...)
 */
 
-typedef std::array<byte,8> Duid;
-typedef std::array<byte,4> Muid;
+typedef std::array<uint8_t,8> Duid;
+typedef std::array<uint8_t,4> Muid;
 
 class CdpPacket {
 public:
   /// Source Device UID (8 bytes)
-  std::array<byte,8> sduid;
+  std::array<uint8_t,8> sduid;
   /// Destination Device UID (8 bytes)
-  std::array<byte,8> dduid;
+  std::array<uint8_t,8> dduid;
   /// Message UID (4 bytes)
-  std::array<byte,4> muid;
+  std::array<uint8_t,4> muid;
   /// Message topic (1 byte)
-  byte topic;
+  uint8_t topic;
   /// Offset to the Path section (1 byte)
-  byte path_offset;
+  uint8_t path_offset;
   /// Type of ducks as define in DuckTypes.h
-  byte duckType;
+  uint8_t duckType;
   /// Number of times a packet was relayed in the mesh
-  byte hopCount;
+  uint8_t hopCount;
   /// crc32 for the data section
   uint32_t dcrc;
   /// Data section
-  std::vector<byte> data;
+  std::vector<uint8_t> data;
   /// Path section (48 bytes max)
   //std::array<byte,48> path;
   //time received
@@ -174,7 +174,7 @@ public:
   CdpPacket() {
     reset();
   }
-  CdpPacket(const std::vector<byte> & buffer) {
+  CdpPacket(const std::vector<uint8_t> & buffer) {
       int buffer_length = buffer.size();
       // sduid
       std::copy(&buffer[SDUID_POS], &buffer[DDUID_POS], sduid.begin());
@@ -202,8 +202,8 @@ public:
    *
    */
   void reset() {
-    std::array<byte,8>().swap(sduid);
-    std::array<byte,4>().swap(muid);
+    std::array<uint8_t,8>().swap(sduid);
+    std::array<uint8_t,4>().swap(muid);
     //std::array<byte,8>().swap(path);
     data.clear();
     duckType = DuckType::UNKNOWN;

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -111,7 +111,7 @@ int DuckNet::setupWebServer(bool createCaptivePortal, std::string html) {
     clientId = duckutils::toUpperCase(clientId); 
     val = "[" + clientId + "]" + val;
 
-    std::vector<byte> data;
+    std::vector<uint8_t> data;
     data.insert(data.end(), val.begin(), val.end());
     //TODO: send the correct ducktype. Probably need the ducktype when DuckNet is created or setup
     txPacket->prepareForSending(bloomFilter, ZERO_DUID, DuckType::UNKNOWN, topics::cpm, data );

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -59,7 +59,7 @@ ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, s
   return rreq;
 }
 
-ArduinoJson::JsonDocument DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument rreq, std::array<uint8_t ,8> currentDevice) {
+void DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument& rreq, std::array<uint8_t ,8> currentDevice) {
     ArduinoJson::JsonArray path = rreq["path"].to<ArduinoJson::JsonArray>();
     path.add(duckutils::arrayToHexString(currentDevice));
     rreq["path"] = path;
@@ -68,7 +68,6 @@ ArduinoJson::JsonDocument DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument rreq,
     serializeJson(rreq, log);
     logdbg_ln("RREQ: %s", log.c_str());
 #endif
-    return rreq;
 }
 
 int DuckPacket::prepareForSending(BloomFilter *filter,

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -71,8 +71,8 @@ ArduinoJson::JsonDocument DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument rreq,
 }
 
 int DuckPacket::prepareForSending(BloomFilter *filter,
-                                  std::array<byte,8> targetDevice, byte duckType,
-                                  byte topic, std::vector<uint8_t> app_data) {
+                                  std::array<uint8_t ,8> targetDevice, uint8_t duckType,
+                                  uint8_t topic, std::vector<uint8_t> app_data) {
 
   std::vector<uint8_t> encryptedData;
   uint8_t app_data_length = app_data.size();

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -49,7 +49,7 @@ void DuckPacket::getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUI
 ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t,8> sourceDevice) {
     ArduinoJson::JsonObject rreq = ArduinoJson::JsonObject();
     rreq["origin"] = duckutils::arrayToHexString(sourceDevice);
-    rreq["destination"] = duckutils::arrayToHexString(targetDevice);
+    rreq["destination"] = targetDevice.data();
     rreq["path"] = ArduinoJson::JsonArray();
 #ifdef CDP_LOG_DEBUG
     std::string log;
@@ -59,9 +59,9 @@ ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, s
   return rreq;
 }
 
-void DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument& rreq, std::array<uint8_t ,8> currentDevice) {
+void DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument& rreq, std::array<uint8_t,8> currentDevice) {
     ArduinoJson::JsonArray path = rreq["path"].to<ArduinoJson::JsonArray>();
-    path.add(duckutils::arrayToHexString(currentDevice));
+    path.add(currentDevice.data());
     rreq["path"] = path;
 #ifdef CDP_LOG_DEBUG
     std::string log;

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 
-bool DuckPacket::prepareForRelaying(BloomFilter *filter, std::vector<byte> dataBuffer) {
+bool DuckPacket::prepareForRelaying(BloomFilter *filter, std::vector<uint8_t> dataBuffer) {
 
 
   this->reset();
@@ -46,7 +46,7 @@ void DuckPacket::getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUI
   }
 }
 
-ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<byte,8> targetDevice, std::array<uint8_t,8> sourceDevice) {
+ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t,8> sourceDevice) {
     ArduinoJson::JsonObject rreq = ArduinoJson::JsonObject();
     rreq["origin"] = duckutils::convertToHex(sourceDevice.data(), sourceDevice.size());
     rreq["path"] = ArduinoJson::JsonArray();

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -50,7 +50,7 @@ ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, s
     ArduinoJson::JsonObject rreq = ArduinoJson::JsonObject();
     rreq["origin"] = duckutils::arrayToHexString(sourceDevice);
     rreq["destination"] = targetDevice.data();
-    rreq["path"] = ArduinoJson::JsonArray();
+    rreq["path"].as<ArduinoJson::JsonArray>();
 #ifdef CDP_LOG_DEBUG
     std::string log;
     serializeJson(rreq, log);

--- a/src/DuckPacket.cpp
+++ b/src/DuckPacket.cpp
@@ -48,7 +48,8 @@ void DuckPacket::getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUI
 
 ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t,8> sourceDevice) {
     ArduinoJson::JsonObject rreq = ArduinoJson::JsonObject();
-    rreq["origin"] = duckutils::convertToHex(sourceDevice.data(), sourceDevice.size());
+    rreq["origin"] = duckutils::arrayToHexString(sourceDevice);
+    rreq["destination"] = duckutils::arrayToHexString(targetDevice);
     rreq["path"] = ArduinoJson::JsonArray();
 #ifdef CDP_LOG_DEBUG
     std::string log;
@@ -58,9 +59,9 @@ ArduinoJson::JsonDocument DuckPacket::RREQ(std::array<uint8_t,8> targetDevice, s
   return rreq;
 }
 
-ArduinoJson::JsonDocument DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument rreq, std::array<uint8_t ,8> targetDevice) {
+ArduinoJson::JsonDocument DuckPacket::UpdateRREQ(ArduinoJson::JsonDocument rreq, std::array<uint8_t ,8> currentDevice) {
     ArduinoJson::JsonArray path = rreq["path"].to<ArduinoJson::JsonArray>();
-    path.add(duckutils::convertToHex(targetDevice.data(), targetDevice.size()));
+    path.add(duckutils::arrayToHexString(currentDevice));
     rreq["path"] = path;
 #ifdef CDP_LOG_DEBUG
     std::string log;

--- a/src/DuckRadio.cpp
+++ b/src/DuckRadio.cpp
@@ -142,7 +142,7 @@ int DuckRadio::setupRadio(LoraConfigParams config) {
     return DUCK_ERR_NONE;
 }
 
-int DuckRadio::setSyncWord(byte syncWord) {
+int DuckRadio::setSyncWord(uint8_t syncWord) {
     if (!isSetup) {
         logerr_ln("ERROR  LoRa radio not setup");
         return DUCKLORA_ERR_NOT_INITIALIZED;
@@ -163,7 +163,7 @@ int DuckRadio::goToReceiveMode(bool clearReceiveFlag) {
     return startReceive();
 }
 
-int DuckRadio::readReceivedData(std::vector<byte>* packetBytes) {
+int DuckRadio::readReceivedData(std::vector<uint8_t>* packetBytes) {
 
     int packet_length = 0;
     int err = DUCK_ERR_NONE;
@@ -232,7 +232,7 @@ int DuckRadio::readReceivedData(std::vector<byte>* packetBytes) {
     return err;
 }
 
-int DuckRadio::sendData(byte* data, int length)
+int DuckRadio::sendData(uint8_t* data, int length)
 {
 
     if (!isSetup) {
@@ -473,7 +473,7 @@ void DuckRadio::onInterrupt(void) {
     interruptFlags = lora.getIrqFlags();
 }
 
-int DuckRadio::startTransmitData(byte* data, int length) {
+int DuckRadio::startTransmitData(uint8_t* data, int length) {
     int err = DUCK_ERR_NONE;
     int tx_err = RADIOLIB_ERR_NONE;
 

--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -68,14 +68,14 @@ void Duck::logIfLowMemory() {
   }
 }
 
-int Duck::setDeviceId(std::array<byte,8>& id) {
+int Duck::setDeviceId(std::array<uint8_t,8>& id) {
   std::copy(id.begin(), id.end(),duid.begin());
   loginfo_ln("setupDeviceId rc = %d",DUCK_ERR_NONE);
   return DUCK_ERR_NONE;
 }
 
 
-int Duck::setDeviceId(byte* id) {
+int Duck::setDeviceId(uint8_t* id) {
     if (id == nullptr) {
         logerr_ln("ERROR  device id empty or address invalid = %d", DUCK_ERR_SETUP);
         return DUCK_ERR_SETUP;

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -58,7 +58,7 @@ void MamaDuck::run() {
 
 void MamaDuck::handleReceivedPacket() {
 
-  std::vector<byte> data;
+  std::vector<uint8_t> data;
   bool relay = false;
   
   loginfo_ln("====> handleReceivedPacket: START");
@@ -116,7 +116,7 @@ void MamaDuck::handleReceivedPacket() {
           }
       }
     } else if(duckutils::isEqual(duid, packet.dduid)) { //Target device check
-        std::vector<byte> dataPayload;
+        std::vector<uint8_t> dataPayload;
         byte num = 1;
       
       switch(packet.topic) {
@@ -154,8 +154,8 @@ void MamaDuck::handleReceivedPacket() {
 
 void MamaDuck::handleCommand(const CdpPacket & packet) {
   int err;
-  std::vector<byte> dataPayload;
-  std::vector<byte> alive {'I','m',' ','a','l','i','v','e'};
+  std::vector<uint8_t> dataPayload;
+  std::vector<uint8_t> alive {'I','m',' ','a','l','i','v','e'};
 
   switch(packet.data[0]) {
     case 0:

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -92,7 +92,6 @@ void MamaDuck::handleReceivedPacket() {
             logerr_ln("ERROR failed to send pong message. rc = %d",err);
           }
           return;
-        break;
         case reservedTopic::pong:
           loginfo_ln("PONG received. Ignoring!");
         break;

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -122,7 +122,7 @@ void PapaDuck::handleReceivedPacket() {
 
 void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value) {
   loginfo_ln("Initiate sending command");
-  std::vector<byte> dataPayload;
+  std::vector<uint8_t> dataPayload;
   dataPayload.push_back(cmd);
   dataPayload.insert(dataPayload.end(), value.begin(), value.end());
 
@@ -143,7 +143,7 @@ void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value) {
   }
 }
 
-void PapaDuck::sendCommand(byte cmd, std::vector<uint8_t> value, std::array<uint8_t,8> dduid) {
+void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value, std::array<uint8_t,8> dduid) {
   loginfo_ln("Initiate sending command");
   std::vector<byte> dataPayload;
   dataPayload.push_back(cmd);

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -1,6 +1,6 @@
 #include "../PapaDuck.h"
 #include <cassert>
-int PapaDuck::setupWithDefaults(std::array<byte,8> deviceId, std::string ssid, std::string password) {
+int PapaDuck::setupWithDefaults(std::array<uint8_t,8> deviceId, std::string ssid, std::string password) {
   loginfo_ln("setupWithDefaults...");
 
   int err = Duck::setupWithDefaults(deviceId, ssid, password);
@@ -90,7 +90,7 @@ void PapaDuck::run() {
 void PapaDuck::handleReceivedPacket() {
 
   loginfo_ln("handleReceivedPacket() START");
-  std::vector<byte> data;
+  std::vector<uint8_t> data;
   int err = duckRadio.readReceivedData(&data);
 
   if (err != DUCK_ERR_NONE) {
@@ -120,7 +120,7 @@ void PapaDuck::handleReceivedPacket() {
   loginfo_ln("handleReceivedPacket() DONE");
 }
 
-void PapaDuck::sendCommand(byte cmd, std::vector<byte> value) {
+void PapaDuck::sendCommand(uint8_t cmd, std::vector<uint8_t> value) {
   loginfo_ln("Initiate sending command");
   std::vector<byte> dataPayload;
   dataPayload.push_back(cmd);
@@ -143,7 +143,7 @@ void PapaDuck::sendCommand(byte cmd, std::vector<byte> value) {
   }
 }
 
-void PapaDuck::sendCommand(byte cmd, std::vector<byte> value, std::array<byte,8> dduid) {
+void PapaDuck::sendCommand(byte cmd, std::vector<uint8_t> value, std::array<uint8_t,8> dduid) {
   loginfo_ln("Initiate sending command");
   std::vector<byte> dataPayload;
   dataPayload.push_back(cmd);

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -288,7 +288,7 @@ protected:
   class DuckRecord {
     public:
       //DuckRecord() : routingScore(0), lastSeen(0), snr(0), rssi(0) {}
-      DuckRecord(std::string devId, long routingScore, long lastSeen, long snr, long rssi) :
+      DuckRecord(std::string devId, long routingScore, long lastSeen, float snr, float rssi) :
         DeviceId(std::move(devId)), routingScore(routingScore), lastSeen(lastSeen), snr(snr), rssi(rssi) {}
 
       std::string getDeviceId() { return DeviceId; }
@@ -375,7 +375,7 @@ protected:
    * The default implementation simply initializes the serial interface.
    * It can be overriden by each concrete Duck class implementation.
    */
-  virtual int setupWithDefaults(std::array<byte,8> deviceId, std::string ssid, std::string password) {
+  virtual int setupWithDefaults(std::array<uint8_t,8> deviceId, std::string ssid, std::string password) {
     int err = setupSerial();
     if (err != DUCK_ERR_NONE) {
       return err;

--- a/src/include/DuckPacket.h
+++ b/src/include/DuckPacket.h
@@ -53,7 +53,7 @@ public:
      * @param duid a duck device unique id
      * @param filter a bloom filter
      */
-        DuckPacket(std::array<byte,8> duid)
+        DuckPacket(std::array<uint8_t,8> duid)
         : duid(duid) {
             buffer.reserve(256);
             }
@@ -64,7 +64,7 @@ public:
      *
      * @param duid a duck device unique id
      */
-    void setDeviceId(std::array<byte,8> duid) { this->duid = duid; }
+    void setDeviceId(std::array<uint8_t,8> duid) { this->duid = duid; }
 
     /**
      * @brief Get device Id.
@@ -80,7 +80,7 @@ public:
      * @param app_data a byte buffer that contains the packet data section
      * @returns DUCK_ERR_NONE if the operation was successful, otherwise an error code.
      */
-    int prepareForSending(BloomFilter *filter, const std::array<byte,8> targetDevice,
+    int prepareForSending(BloomFilter *filter, const std::array<uint8_t,8> targetDevice,
                           byte duckType, byte topic, std::vector<byte> app_data);
 
     /**
@@ -91,7 +91,7 @@ public:
      * @returns true if the packet needs to be relayed
      * @returns false if the packet does not need to be replayed
      */
-    bool prepareForRelaying(BloomFilter *filter, std::vector<byte> dataBuffer);
+    bool prepareForRelaying(BloomFilter *filter, std::vector<uint8_t> dataBuffer);
     
     /**
      * @brief Get the Cdp Packet byte array.
@@ -118,27 +118,27 @@ public:
     /**
  * @brief Build a RREQ packet.
  *
- * @param targetDevice the target device DUID to receive the message
+ *
  * @param sourceDevice the source device DUID to send the message
  * @returns a JSON Document representing the RREQ packet
  */
-    ArduinoJson::JsonDocument RREQ(std::array<byte, 8> targetDevice, std::array<byte, 8> sourceDevice);
+    ArduinoJson::JsonDocument RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t, 8> sourceDevice);
 
 /**
- * @brief Update a RREQ packet with the target device.
+ * @brief Update a RREQ packet with the current node's DUID.
  *
  * @param rreq the RREQ packet to update
- * @param targetDevice the target device DUID to receive the message
+ * @param currentDevice the device DUID to of the current node
  * @returns a JSON Document representing the updated RREQ packet
  */
-    ArduinoJson::JsonDocument UpdateRREQ(ArduinoJson::JsonDocument rreq, std::array<byte, 8> targetDevice);
+    ArduinoJson::JsonDocument UpdateRREQ(ArduinoJson::JsonDocument rreq, std::array<uint8_t, 8> currentDevice);
 
     /**
      * @brief Get the data section of the packet.
      *
      * @returns a vector of bytes representing the data section
      */
-    std::vector<byte> getDataSection() { return std::vector<byte>(buffer.begin() + DATA_POS, buffer.end()); }
+    std::vector<uint8_t> getDataSection() { return std::vector<uint8_t>(buffer.begin() + DATA_POS, buffer.end()); }
 };
 
 #endif

--- a/src/include/DuckPacket.h
+++ b/src/include/DuckPacket.h
@@ -98,7 +98,7 @@ public:
      * 
      * @returns a array of bytes representing the cdp packet
      */
-    std::vector<byte> getBuffer() { return buffer;}
+    std::vector<uint8_t> getBuffer() { return buffer;}
 
     /**
      * @brief Resets the packet byte buffer.

--- a/src/include/DuckPacket.h
+++ b/src/include/DuckPacket.h
@@ -14,21 +14,21 @@
  * @brief Use this DUID to send to all PapaDucks
  * 
  */
-static std::array<byte,8> ZERO_DUID = {0x00, 0x00, 0x00, 0x00,
+static std::array<uint8_t,8> ZERO_DUID = {0x00, 0x00, 0x00, 0x00,
                                       0x00, 0x00, 0x00, 0x00};
 
 /**
  * @brief Use this DUID to be received by every duck in the network
  * 
  */
-static std::array<byte,8> BROADCAST_DUID = {0xFF, 0xFF, 0xFF, 0xFF,
+static std::array<uint8_t,8> BROADCAST_DUID = {0xFF, 0xFF, 0xFF, 0xFF,
                                            0xFF, 0xFF, 0xFF, 0xFF};
 
 /**
  * @brief Use this DUID to be received by every duck in the network
  * 
  */
-static std::array<byte,8> PAPADUCK_DUID = {0x50, 0x61, 0x70, 0x61,
+static std::array<uint8_t,8> PAPADUCK_DUID = {0x50, 0x61, 0x70, 0x61,
                                            0x44, 0x75, 0x63, 0x6B};
 
 /**
@@ -71,7 +71,7 @@ public:
      *
      * @returns a duck device unique id
      */
-    std::array<byte,8> getDeviceId() { return this->duid = duid; }
+    std::array<uint8_t,8> getDeviceId() { return this->duid; }
     /**
      * @brief Build a packet from the given topic and provided byte buffer.
      *
@@ -81,7 +81,7 @@ public:
      * @returns DUCK_ERR_NONE if the operation was successful, otherwise an error code.
      */
     int prepareForSending(BloomFilter *filter, const std::array<uint8_t,8> targetDevice,
-                          byte duckType, byte topic, std::vector<byte> app_data);
+                          uint8_t duckType, uint8_t topic, std::vector<uint8_t> app_data);
 
     /**
      * @brief Update a received packet if it needs to be relayed in the mesh.
@@ -108,21 +108,16 @@ public:
       buffer.clear();
     }
 
-    byte getTopic() { return buffer[TOPIC_POS]; }
+    uint8_t getTopic() { return buffer[TOPIC_POS]; }
 
-  private: 
-    std::array<byte,8> duid;
-    std::vector<byte> buffer;
-
-    static void getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUID_LENGTH> &message_id);
-    /**
- * @brief Build a RREQ packet.
- *
- *
- * @param sourceDevice the source device DUID to send the message
- * @returns a JSON Document representing the RREQ packet
- */
-    ArduinoJson::JsonDocument RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t, 8> sourceDevice);
+/**
+* @brief Build a RREQ packet.
+*
+*
+* @param sourceDevice the source device DUID to send the message
+* @returns a JSON Document representing the RREQ packet
+*/
+   static ArduinoJson::JsonDocument RREQ(std::array<uint8_t,8> targetDevice, std::array<uint8_t, 8> sourceDevice);
 
 /**
  * @brief Update a RREQ packet with the current node's DUID.
@@ -131,7 +126,13 @@ public:
  * @param currentDevice the device DUID to of the current node
  * @returns a JSON Document representing the updated RREQ packet
  */
-    ArduinoJson::JsonDocument UpdateRREQ(ArduinoJson::JsonDocument rreq, std::array<uint8_t, 8> currentDevice);
+   static void UpdateRREQ(ArduinoJson::JsonDocument& rreq, std::array<uint8_t, 8> currentDevice);
+
+  private: 
+    std::array<uint8_t,8> duid;
+    std::vector<uint8_t> buffer;
+
+    static void getUniqueMessageId(BloomFilter * filter, std::array<uint8_t,MUID_LENGTH> &message_id);
 
     /**
      * @brief Get the data section of the packet.

--- a/src/include/DuckUtils.h
+++ b/src/include/DuckUtils.h
@@ -39,7 +39,7 @@ std::string toUpperCase(std::string str);
  * @param str the string to convert
  * @returns A vector of bytes.
  */
-std::vector<byte> stringToByteVector(const String& str);
+std::vector<uint8_t> stringToByteVector(const std::string& str);
 
 /**
  * @brief Creates a byte array with random alpha numerical values.


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
A brief description of changes made in this PR.
I made `UpdateRREQ()` and `RREQ()` static and public because they have to be used in `MamaDuck.cpp`, which is outside the `DuckPacket` class.
**Related Issues:**  
none
**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [ ] Updated relevant documentation
- [ ] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
