### PR TITLE
add T-Beam Supreme Support

### DIFF
--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -10,12 +10,14 @@
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_lilygo_t_beam_sx1276
 ;   default_envs = local_lilygo_t_beam_sx1262
+;   default_envs = local_lilygo_t_beam_supreme_sx1262
 ;   default_envs = local_ttgo_lora32_v1_3
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_lilygo_t_beam_sx1276
 ;   default_envs = prod_lilygo_t_beam_sx1262
+;   default_envs = prod_lilygo_t_beam_supreme_sx1262
 ;   default_envs = prod_ttgo_lora32_v1_3
 
 
@@ -59,6 +61,19 @@
   [env:prod_lilygo_t_beam_sx1262]
     extends = env:release_cdp
     board = ttgo-t-beam
+
+  ; PRODUCTION LILYGO_T_BEAM_SUPREME_SX1262
+  [env:prod_lilygo_t_beam_supreme_sx1262]
+    extends = env:release_cdp
+    board = esp32-s3-devkitc-1
+    build_flags =
+      ${env:release_cdp.build_flags}
+      -DARDUINO_LILYGO_T_BEAM_SUPREME
+      -DARDUINO_USB_MODE=1
+      -DARDUINO_USB_CDC_ON_BOOT=1
+      -DBOARD_HAS_PSRAM
+    upload_speed = 921600
+    monitor_speed = 115200
     
   ; PRODUCTION TTGO_LORA32_V1
   [env:prod_lilygo_t_beam_sx1276]
@@ -90,6 +105,19 @@
   [env:local_lilygo_t_beam_sx1262]
     extends = env:local_cdp 
     board = ttgo-t-beam
+
+  ; LOCAL LILYGO_T_BEAM_SUPREME_SX1262
+  [env:local_lilygo_t_beam_supreme_sx1262]
+    extends = env:local_cdp
+    board = esp32-s3-devkitc-1
+    build_flags =
+      ${env:local_cdp.build_flags}
+      -DARDUINO_LILYGO_T_BEAM_SUPREME
+      -DARDUINO_USB_MODE=1
+      -DARDUINO_USB_CDC_ON_BOOT=1
+      -DBOARD_HAS_PSRAM
+    upload_speed = 921600
+    monitor_speed = 115200
 
   ; LOCAL TTGO_LORA32_V1
   [env:local_lilygo_t_beam_sx1276]

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,20 +25,22 @@ extra_scripts = pre:tools/example_select.py
   description = ClusterDuck Protocol Library
   lib_dir = ./src
   extra_configs = src/config/*.ini
-  src_dir = ./examples/Basic-Ducks/MamaDuck
+  src_dir = ./examples/Custom-Mama-Examples/Custom-Mama-Example
 
 ; uncomment the line below to build for your board
    
-  default_envs = local_heltec_wifi_lora_32_V3
+  default_envs = local_lilygo_t_beam_supreme_sx1262
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_lilygo_t_beam_sx1276
 ;   default_envs = local_lilygo_t_beam_sx1262
+;   default_envs = local_lilygo_t_beam_supreme_sx1262
 ;   default_envs = local_ttgo_lora32_v1_3
 
 ;   default_envs = prod_heltec_wifi_lora_32_V3
 ;   default_envs = prod_heltec_wifi_lora_32_V2
 ;   default_envs = prod_lilygo_t_beam_sx1276
 ;   default_envs = prod_lilygo_t_beam_sx1262
+;   default_envs = prod_lilygo_t_beam_supreme_sx1262
 ;   default_envs = prod_ttgo_lora32_v1_3
 
 ;  default_envs = test_heltec_wifi_lora_32_V3
@@ -87,6 +89,19 @@ extra_scripts = pre:tools/example_select.py
     extends = env:release_cdp
     board = ttgo-t-beam
 
+  ; PRODUCTION LILYGO_T_BEAM_SUPREME_SX1262
+  [env:prod_lilygo_t_beam_supreme_sx1262]
+    extends = env:release_cdp
+    board = esp32-s3-devkitc-1
+    build_flags =
+      ${env:release_cdp.build_flags}
+      -DARDUINO_LILYGO_T_BEAM_SUPREME
+      -DARDUINO_USB_MODE=1
+      -DARDUINO_USB_CDC_ON_BOOT=1
+      -DBOARD_HAS_PSRAM
+    upload_speed = 921600
+    monitor_speed = 115200
+
   ; PRODUCTION TTGO_LORA32_V1
   [env:prod_lilygo_t_beam_sx1276]
     extends = env:release_cdp
@@ -118,6 +133,19 @@ extra_scripts = pre:tools/example_select.py
   [env:local_lilygo_t_beam_sx1262]
     extends = env:local_cdp  
     board = ttgo-t-beam
+
+  ; LOCAL LILYGO_T_BEAM_SUPREME_SX1262
+  [env:local_lilygo_t_beam_supreme_sx1262]
+    extends = env:local_cdp
+    board = esp32-s3-devkitc-1
+    build_flags =
+      ${env:local_cdp.build_flags}
+      -DARDUINO_LILYGO_T_BEAM_SUPREME
+      -DARDUINO_USB_MODE=1
+      -DARDUINO_USB_CDC_ON_BOOT=1
+      -DBOARD_HAS_PSRAM
+    upload_speed = 921600
+    monitor_speed = 115200
 
   ; LOCAL TTGO_LORA32_V1
   [env:local_lilygo_t_beam_sx1276]

--- a/src/DuckDisplay.cpp
+++ b/src/DuckDisplay.cpp
@@ -123,13 +123,6 @@ void DuckDisplay::setupDisplay(int duckType, std::array<byte,8> name) {
   u8g2.setFont(u8g2_font_synchronizer_nbp_tf); // choose a suitable font
   u8g2.clearBuffer();  
   
-  // Test basic drawing
-  loginfo_ln("Drawing test pattern...");
-  u8g2.drawStr(0, 15, "CDP Test");
-  u8g2.drawStr(0, 30, "T-Beam Supreme");
-  u8g2.sendBuffer();
-  delay(2000);
-  
   // Draw logo
   loginfo_ln("Drawing CDP logo...");
   u8g2.clearBuffer();

--- a/src/include/boards/README.md
+++ b/src/include/boards/README.md
@@ -1,6 +1,16 @@
 # Adding Your Own Board
 This directory contains board-specific files for the various boards that are supported by the CDP firmware.
 
+## Supported Boards
+
+The ClusterDuck Protocol currently supports the following boards out of the box:
+
+- **Heltec WiFi LoRa 32 V2** - `src/include/boards/heltec_wifi_lora_32_V2.h`
+- **Heltec WiFi LoRa 32 V3** - `src/include/boards/heltec_wifi_lora_32_V3.h`
+- **LilyGO T-Beam SX1262** - `src/include/boards/lilygo_t_beam_sx1262.h`
+- **LilyGO T-Beam Supreme ESP32-S3 SX1262** - `src/include/boards/lilygo_t_beam_supreme_sx1262.h`
+- **TTGO T-Beam V1 SX1276** - `src/include/boards/ttgo_t_beam_v1_sx1276.h`
+
 ## Board Format
 Some boards will differ in capability, so not all pins will need to be defined. All pins starting 
 Here is what a board file should look like to start:

--- a/src/include/boards/lilygo_t_beam_supreme_sx1262.h
+++ b/src/include/boards/lilygo_t_beam_supreme_sx1262.h
@@ -1,0 +1,48 @@
+#pragma once
+
+/*
+ * BOARD "T-Beam Supreme"
+ * LilyGO T-Beam Supreme ESP32-S3 with SX1262 LoRa
+ * https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/docs/en/t_beam_supreme/t_beam_supreme_hw.md
+ * (GPS module, OLED display, and 18650 holder)
+ */
+#if defined(ARDUINO_LILYGO_T_BEAM_SUPREME) || defined(ARDUINO_lilygo_t_beam_supreme) || defined(ARDUINO_ESP32S3_DEV)
+
+#define CDP_BOARD_NAME "LilyGO T-Beam Supreme ESP32-S3 SX1262"
+#define CDPCFG_RADIO_SX1262
+
+// Uncomment this to enable the OLED display
+#define ENABLE_DISPLAY
+
+// Battery monitoring (using safe ESP32-S3 ADC pin, avoiding strapping pins)
+#define CDPCFG_PIN_BAT 2
+#define CDPCFG_BAT_MULDIV 200 / 100
+
+// LED (avoid strapping pins, use available GPIO)  
+#define CDPCFG_PIN_LED1 48  // RGB LED pin on many ESP32-S3 boards
+
+// GPS configuration (updated to match LilyGO T-Beam Supreme specs)
+#define CDPCFG_GPS_RX 9    // GNSS RX (T-Beam Supreme standard)
+#define CDPCFG_GPS_TX 8    // GNSS TX (T-Beam Supreme standard)
+
+// LoRa configuration for SX1262 (avoiding strapping pins)
+#define CDPCFG_PIN_LORA_CS      10  // LoRa CS
+#define CDPCFG_PIN_LORA_RST     5   // LoRa RESET
+#define CDPCFG_PIN_LORA_DIO0    -1  // Not used in SX1262
+#define CDPCFG_PIN_LORA_DIO1    6   // LoRa DIO1/DIO9 (SX1262 IRQ) - Changed from GPIO1 (strapping pin)
+#define CDPCFG_PIN_LORA_BUSY    4   // LoRa BUSY
+
+// OLED display settings (corrected I2C pin assignments)
+#ifdef ENABLE_DISPLAY
+#define CDPCFG_PIN_OLED_CLOCK   18   // SCL (T-Beam Supreme I2C standard)
+#define CDPCFG_PIN_OLED_DATA    17   // SDA (T-Beam Supreme I2C standard)  
+#define CDPCFG_PIN_OLED_RESET   -1   // Usually shared reset or not needed
+#define CDPCFG_PIN_OLED_ROTATION U8G2_R0
+
+// Define the OLED class for SH1106 controller (software I2C for better reliability)
+#define CDPCFG_OLED_CLASS U8G2_SH1106_128X64_NONAME_F_SW_I2C
+#else
+#define CDPCFG_OLED_NONE
+#endif
+
+#endif 

--- a/src/include/cdpcfg.h
+++ b/src/include/cdpcfg.h
@@ -18,6 +18,7 @@
 #include "boards/heltec_wifi_lora_32_V3.h"
 #include "boards/heltec_wifi_lora_32_V2.h"
 #include "boards/lilygo_t_beam_sx1262.h"
+#include "boards/lilygo_t_beam_supreme_sx1262.h"
 #include "boards/ttgo_t_beam_v1_sx1276.h"
 #endif
 


### PR DESCRIPTION
### New Board Support

####  LilyGO T-Beam Supreme Configuration
- **New board file**: `src/include/boards/lilygo_t_beam_supreme_sx1262.h`
  - ESP32-S3 optimized pin assignments avoiding strapping pins
  - SX1262 LoRa radio configuration
  - U-Blox GPS support (RX: GPIO9, TX: GPIO8)
  - SH1106 OLED display support (SDA: GPIO17, SCL: GPIO18)
  - USB CDC support with proper build flags

####  PlatformIO Integration
- **Added build environments**:
  - `local_lilygo_t_beam_supreme_sx1262` - Development builds
  - `prod_lilygo_t_beam_supreme_sx1262` - Production builds
- **ESP32-S3 specific build flags**:
  - `-DARDUINO_LILYGO_T_BEAM_SUPREME`
  - `-DARDUINO_USB_MODE=1` 
  - `-DARDUINO_USB_CDC_ON_BOOT=1`
  - `-DBOARD_HAS_PSRAM`
  -Needed to add this for proper building and flashing

### Display System Improvements

####  Enhanced OLED Driver Support
- **Improved conditional compilation** for display handling
  - Proper `#ifdef ENABLE_DISPLAY` guards following board patterns
  - Added fallback `#define CDPCFG_OLED_NONE` when disabled
  - Support for SH1106 controller via software I2C
